### PR TITLE
Fix issues on chez, where srfis would not import

### DIFF
--- a/private/include/compat.chezscheme.sls
+++ b/private/include/compat.chezscheme.sls
@@ -15,5 +15,8 @@
 ;;; PERFORMANCE OF THIS SOFTWARE.
 
 (library (srfi private include compat)
-  (export (rename (source-directories search-paths)))
-  (import (only (chezscheme) source-directories)))
+  (export search-paths)
+  (import (rnrs) (only (chezscheme) library-directories))
+
+  (define (search-paths) (map car (library-directories)))
+)


### PR DESCRIPTION
Use of search-paths fails to take into account --libdirs command-line option on chez / petite, and thus fails to find load any srfis using include/resolve unless the srfi directory is a direct child of the current working directory. 
