### PR TITLE
Add <> and <...> to exports

### DIFF
--- a/%3a26.sls
+++ b/%3a26.sls
@@ -3,6 +3,8 @@
 (library (srfi :26)
   (export
     cut
-    cute)
+    cute
+    <>
+    <...>)
   (import (srfi :26 cut))
 )

--- a/%3a26/cut.scm
+++ b/%3a26/cut.scm
@@ -85,6 +85,11 @@
 
 ; exported syntax
 
+(define-syntax (<> x)
+  (syntax-violation #f "misplaced aux keyword <>"))
+(define-syntax (<...> x)
+  (syntax-violation #f "misplaced aux keyword <...>"))
+
 (define-syntax cut
   (syntax-rules ()
     ((cut . slots-or-exprs)

--- a/%3a26/cut.sls
+++ b/%3a26/cut.sls
@@ -3,7 +3,7 @@
 ;; LICENSE from the original collection this file is distributed with.
 
 (library (srfi :26 cut)
-  (export cut cute)
+  (export cut cute <> <...>)
   (import (rnrs) (srfi private include))
   
   (include/resolve ("srfi" "%3a26") "cut.scm")  


### PR DESCRIPTION
This srfi does not work without defining `<>` and `<...>` as identifiers and exporting them from the library.
Before patch:
```
> (expand '(cut + 10 <>))
(lambda () (#2%+ 10 <>))
```
```
> (expand '(cut + <...>))
(lambda () (#2%+ <...>))
```
After patch:
```
> (expand '(cut + 10 <>))
(lambda (#{x eokbcvvxlnk2f2d5zqbn04-4})
  (#2%+ 10 #{x eokbcvvxlnk2f2d5zqbn04-4}))
```
```
> (expand '(cut + <...>))
(lambda #{rest-slot eocuif8tsjn5qd5v1yewuf-4}
  (#2%apply #2%+ #{rest-slot eocuif8tsjn5qd5v1yewuf-4}))
```