### PR TITLE
Optimized (srfi :1 lists)

### DIFF
--- a/%3a1/lists.sls
+++ b/%3a1/lists.sls
@@ -46,29 +46,16 @@
     ;; different than R6RS:
     assoc filter find fold-right for-each map member partition remove)
   (import
-    (except (rnrs)
-            assoc filter find fold-right for-each map member partition remove)
+    (rename (except (rnrs) find filter fold-right map partition remove)
+            (assoc r6rs:assoc)
+            (for-each r6rs:for-each)
+            (member r6rs:member))
     (rnrs mutable-pairs)
     (srfi :8 receive)
     (srfi :23 error tricks)
     (for (srfi private vanish) expand)
     (srfi private check-arg)
     (srfi private include))
-
-  (define-syntax :optional
-    (syntax-rules ()
-      ((_ args default)
-       (let ((a args))
-         (if (pair? a) (car a) default)))))
-
-  (define-syntax let-optionals
-    (syntax-rules ()
-      ((_ _ () . body)
-       (let () . body))
-      ((_ args ((id default) . more) . body)
-       (let ((a args))
-         (let ((id (:optional a default)))
-           (let-optionals (if (pair? a) (cdr a) '()) more . body))))))
 
   (let-syntax ((define (vanish-define define (cons*))))
     (SRFI-23-error->R6RS "(library (srfi :1 lists))"

--- a/%3a1/srfi-1-reference.scm
+++ b/%3a1/srfi-1-reference.scm
@@ -1,10 +1,14 @@
-;;; SRFI-1 list-processing library 			-*- Scheme -*-
+;;; SRFI-1 list-processing library                      -*- Scheme -*-
 ;;; Reference implementation
 ;;;
 ;;; Copyright (c) 1998, 1999 by Olin Shivers. You may do as you please with
 ;;; this code as long as you do not remove this copyright notice or
 ;;; hold me liable for its use. Please send bug reports to shivers@ai.mit.edu.
 ;;;     -Olin
+
+;;; Copyright (c) Jéssica Milaré, 2018. You may do as you please with
+;;; this code as long as you do not remove this copyright notice or
+;;; hold me liable for its use.
 
 ;;; This is a library of list- and pair-processing functions. I wrote it after
 ;;; carefully considering the functions provided by the libraries found in
@@ -156,8 +160,6 @@
 ;;;    (define (check-arg pred val caller)
 ;;;      (let lp ((val val))
 ;;;        (if (pred val) val (lp (error "Bad argument" val pred caller)))))
-;;;   A few uses of the LET-OPTIONAL and :OPTIONAL macros for parsing
-;;;     optional arguments.
 ;;;
 ;;; Most of these procedures use the NULL-LIST? test to trigger the
 ;;; base case in the inner loop or recursion. The NULL-LIST? function
@@ -220,110 +222,116 @@
 ;(define (tree-copy x)
 ;  (let recur ((x x))
 ;    (if (not (pair? x)) x
-;	(cons (recur (car x)) (recur (cdr x))))))
+;       (cons (recur (car x)) (recur (cdr x))))))
 
 ;;; Make a list of length LEN.
 
-(define (make-list len . maybe-elt)
-  (check-arg (lambda (n) (and (integer? n) (>= n 0))) len make-list)
-  (let ((elt (cond ((null? maybe-elt) #f) ; Default value
-		   ((null? (cdr maybe-elt)) (car maybe-elt))
-		   (else (error "Too many arguments to MAKE-LIST"
-				(cons len maybe-elt))))))
-    (do ((i len (- i 1))
-	 (ans '() (cons elt ans)))
-	((<= i 0) ans))))
+(define make-list
+  (case-lambda
+    ((len) (make-list len #f))
+    ((len elt)
+     (check-arg index? len make-list)
+     (do ((i len (fx- i 1))
+          (ans '() (cons elt ans)))
+         ((fx<=? i 0) ans)))))
 
 
-;(define (list . ans) ans)	; R4RS
+;(define (list . ans) ans)      ; R4RS
 
 
 ;;; Make a list of length LEN. Elt i is (PROC i) for 0 <= i < LEN.
 
 (define (list-tabulate len proc)
-  (check-arg (lambda (n) (and (integer? n) (>= n 0))) len list-tabulate)
+  (check-arg index? len list-tabulate)
   (check-arg procedure? proc list-tabulate)
-  (do ((i (- len 1) (- i 1))
+  (do ((i (fx- len 1) (fx- i 1))
        (ans '() (cons (proc i) ans)))
-      ((< i 0) ans)))
+      ((fx<? i 0) ans)))
 
 ;;; (cons* a1 a2 ... an) = (cons a1 (cons a2 (cons ... an)))
-;;; (cons* a1) = a1	(cons* a1 a2 ...) = (cons a1 (cons* a2 ...))
+;;; (cons* a1) = a1     (cons* a1 a2 ...) = (cons a1 (cons* a2 ...))
 ;;;
 ;;; (cons first (unfold not-pair? car cdr rest values))
 
-(define (cons* first . rest)
-  (let recur ((x first) (rest rest))
-    (if (pair? rest)
-	(cons x (recur (car rest) (cdr rest)))
-	x)))
+(define cons*
+  (case-lambda
+    ((first) first)
+    ((first second) (cons first second))
+    ((first second third . rest)
+     (cons first
+           (cons second
+                 (let recur ((x third) (rest rest))
+                   (if (pair? rest)
+                       (cons x (recur (car rest) (cdr rest)))
+                       x)))))))
 
 ;;; (unfold not-pair? car cdr lis values)
 
-(define (list-copy lis)				
-  (let recur ((lis lis))			
-    (if (pair? lis)				
-	(cons (car lis) (recur (cdr lis)))	
-	lis)))					
+(define (list-copy lis)
+  (let recur ((lis lis))
+    (if (pair? lis)
+        (cons (car lis) (recur (cdr lis)))
+        lis)))
 
-;;; IOTA count [start step]	(start start+step ... start+(count-1)*step)
+;;; IOTA count [start step]     (start start+step ... start+(count-1)*step)
 
-(define (iota count . maybe-start+step)
-  (check-arg integer? count iota)
-  (if (< count 0) (error "Negative step count" iota count))
-  (let-optionals maybe-start+step ((start 0) (step 1))
-    (check-arg number? start iota)
-    (check-arg number? step iota)
-    (let loop ((n 0) (r '()))
-      (if (= n count)
-	  (reverse r)
-	  (loop (+ 1 n)
-		(cons (+ start (* n step)) r))))))
-	  
+(define iota
+  (case-lambda
+    ((count) (iota count 0 1))
+    ((count start) (iota count start 1))
+    ((count start step)
+     (check-arg index? count iota)
+     (check-arg number? start iota)
+     (check-arg number? step iota)
+     (let loop ((cur start) (n 0))
+       (if (fx=? n count)
+           '()
+           (cons cur (loop (fx+ cur step) (fx+ 1 n))))))))
+
 ;;; I thought these were lovely, but the public at large did not share my
 ;;; enthusiasm...
-;;; :IOTA to		(0 ... to-1)
-;;; :IOTA from to	(from ... to-1)
+;;; :IOTA to            (0 ... to-1)
+;;; :IOTA from to       (from ... to-1)
 ;;; :IOTA from to step  (from from+step ...)
 
-;;; IOTA: to		(1 ... to)
-;;; IOTA: from to	(from+1 ... to)
-;;; IOTA: from to step	(from+step from+2step ...)
+;;; IOTA: to            (1 ... to)
+;;; IOTA: from to       (from+1 ... to)
+;;; IOTA: from to step  (from+step from+2step ...)
 
 ;(define (%parse-iota-args arg1 rest-args proc)
-;  (let ((check (lambda (n) (check-arg integer? n proc))))
+;  (let ((check (lambda (n) (check-arg fixnum? n proc))))
 ;    (check arg1)
 ;    (if (pair? rest-args)
-;	(let ((arg2 (check (car rest-args)))
-;	      (rest (cdr rest-args)))
-;	  (if (pair? rest)
-;	      (let ((arg3 (check (car rest)))
-;		    (rest (cdr rest)))
-;		(if (pair? rest) (error "Too many parameters" proc arg1 rest-args)
-;		    (values arg1 arg2 arg3)))
-;	      (values arg1 arg2 1)))
-;	(values 0 arg1 1))))
+;       (let ((arg2 (check (car rest-args)))
+;             (rest (cdr rest-args)))
+;         (if (pair? rest)
+;             (let ((arg3 (check (car rest)))
+;                   (rest (cdr rest)))
+;               (if (pair? rest) (error "Too many parameters" proc arg1 rest-args)
+;                   (values arg1 arg2 arg3)))
+;             (values arg1 arg2 1)))
+;       (values 0 arg1 1))))
 ;
 ;(define (iota: arg1 . rest-args)
 ;  (receive (from to step) (%parse-iota-args arg1 rest-args iota:)
 ;    (let* ((numsteps (floor (/ (- to from) step)))
-;	   (last-val (+ from (* step numsteps))))
+;          (last-val (+ from (* step numsteps))))
 ;      (if (< numsteps 0) (error "Negative step count" iota: from to step))
 ;      (do ((steps-left numsteps (- steps-left 1))
-;	   (val last-val (- val step))
-;	   (ans '() (cons val ans)))
-;	  ((<= steps-left 0) ans)))))
+;          (val last-val (- val step))
+;          (ans '() (cons val ans)))
+;         ((<= steps-left 0) ans)))))
 ;
 ;
 ;(define (:iota arg1 . rest-args)
 ;  (receive (from to step) (%parse-iota-args arg1 rest-args :iota)
 ;    (let* ((numsteps (ceiling (/ (- to from) step)))
-;	   (last-val (+ from (* step (- numsteps 1)))))
+;          (last-val (+ from (* step (- numsteps 1)))))
 ;      (if (< numsteps 0) (error "Negative step count" :iota from to step))
 ;      (do ((steps-left numsteps (- steps-left 1))
-;	   (val last-val (- val step))
-;	   (ans '() (cons val ans)))
-;	  ((<= steps-left 0) ans)))))
+;          (val last-val (- val step))
+;          (ans '() (cons val ans)))
+;         ((<= steps-left 0) ans)))))
 
 
 
@@ -332,98 +340,115 @@
     (set-cdr! (last-pair ans) ans)
     ans))
 
-;;; <proper-list> ::= ()			; Empty proper list
-;;;		  |   (cons <x> <proper-list>)	; Proper-list pair
+;;; <proper-list> ::= ()                        ; Empty proper list
+;;;               |   (cons <x> <proper-list>)  ; Proper-list pair
 ;;; Note that this definition rules out circular lists -- and this
 ;;; function is required to detect this case and return false.
 
 (define (proper-list? x)
   (let lp ((x x) (lag x))
     (if (pair? x)
-	(let ((x (cdr x)))
-	  (if (pair? x)
-	      (let ((x   (cdr x))
-		    (lag (cdr lag)))
-		(and (not (eq? x lag)) (lp x lag)))
-	      (null? x)))
-	(null? x))))
+        (let ((x (cdr x)))
+          (if (pair? x)
+              (let ((x   (cdr x))
+                    (lag (cdr lag)))
+                (and (not (eq? x lag)) (lp x lag)))
+              (null? x)))
+        (null? x))))
 
 
 ;;; A dotted list is a finite list (possibly of length 0) terminated
 ;;; by a non-nil value. Any non-cons, non-nil value (e.g., "foo" or 5)
 ;;; is a dotted list of length 0.
 ;;;
-;;; <dotted-list> ::= <non-nil,non-pair>	; Empty dotted list
-;;;               |   (cons <x> <dotted-list>)	; Proper-list pair
+;;; <dotted-list> ::= <non-nil,non-pair>        ; Empty dotted list
+;;;               |   (cons <x> <dotted-list>)  ; Proper-list pair
 
 (define (dotted-list? x)
   (let lp ((x x) (lag x))
     (if (pair? x)
-	(let ((x (cdr x)))
-	  (if (pair? x)
-	      (let ((x   (cdr x))
-		    (lag (cdr lag)))
-		(and (not (eq? x lag)) (lp x lag)))
-	      (not (null? x))))
-	(not (null? x)))))
+        (let ((x (cdr x)))
+          (if (pair? x)
+              (let ((x   (cdr x))
+                    (lag (cdr lag)))
+                (and (not (eq? x lag)) (lp x lag)))
+              (not (null? x))))
+        (not (null? x)))))
 
 (define (circular-list? x)
   (let lp ((x x) (lag x))
     (and (pair? x)
-	 (let ((x (cdr x)))
-	   (and (pair? x)
-		(let ((x   (cdr x))
-		      (lag (cdr lag)))
-		  (or (eq? x lag) (lp x lag))))))))
+         (let ((x (cdr x)))
+           (and (pair? x)
+                (let ((x   (cdr x))
+                      (lag (cdr lag)))
+                  (or (eq? x lag) (lp x lag))))))))
 
-(define (not-pair? x) (not (pair? x)))	; Inline me.
+(define (not-pair? x) (not (pair? x)))       ; Inline me.
 
 ;;; This is a legal definition which is fast and sloppy:
 ;;;     (define null-list? not-pair?)
 ;;; but we'll provide a more careful one:
 (define (null-list? l)
   (cond ((pair? l) #f)
-	((null? l) #t)
-	(else (error "null-list?: argument out of domain" l))))
+        ((null? l) #t)
+        (else (error "null-list?: argument out of domain" l))))
            
 
-(define (list= elt= . lists)
-  (or (null? lists) ; special case
-      (let lp1 ((list-a (car lists)) (others (cdr lists)))
-	(or (null? others)
-	    (let ((list-b-orig (car others))
-		  (others      (cdr others)))
-	      (if (eq? list-a list-b-orig)	; EQ? => LIST=
-		  (lp1 list-b-orig others)
-		  (let lp2 ((list-a list-a) (list-b list-b-orig))
-		    (if (null-list? list-a)
-			(and (null-list? list-b)
-			     (lp1 list-b-orig others))
-			(and (not (null-list? list-b))
-			     (elt= (car list-a) (car list-b))
-			     (lp2 (cdr list-a) (cdr list-b)))))))))))
-			
+(define list=
+  (case-lambda
+    ((elt=) #t)
+    ((elt= list-a) #t)
+    ((elt= list-a list-b)
+     (or (eq? list-a list-b)
+         (let loop ((list-a list-a)
+                    (list-b list-b))
+           (if (null-list? list-a)
+               (null-list? list-b)
+               (and (not (null-list? list-b))
+                    (elt= (car list-a) (car list-b))
+                    (loop (cdr list-a) (cdr list-b)))))))
+    ((elt= list-a list-b list-c . lists)
+     (and (list= elt= list-a list-b)
+          (list= elt= list-b list-c)
+          (or (null? lists)
+              (let loop ((list-a list-c) (lists lists))
+                   (let ((list-b (car lists))
+                         (others (cdr lists)))
+                     (and (list= elt= list-a list-b)
+                          (or (null? others)
+                              (loop list-b others))))))))))
+
 
 
 ;;; R4RS, so commented out.
-;(define (length x)			; LENGTH may diverge or
-;  (let lp ((x x) (len 0))		; raise an error if X is
-;    (if (pair? x)			; a circular list. This version
-;        (lp (cdr x) (+ len 1))		; diverges.
+;(define (length x)                     ; LENGTH may diverge or
+;  (let lp ((x x) (len 0))              ; raise an error if X is
+;    (if (pair? x)                      ; a circular list. This version
+;        (lp (cdr x) (+ len 1))         ; diverges.
 ;        len)))
 
-(define (length+ x)			; Returns #f if X is circular.
-  (let lp ((x x) (lag x) (len 0))
-    (if (pair? x)
-	(let ((x (cdr x))
-	      (len (+ len 1)))
-	  (if (pair? x)
-	      (let ((x   (cdr x))
-		    (lag (cdr lag))
-		    (len (+ len 1)))
-		(and (not (eq? x lag)) (lp x lag len)))
-	      len))
-	len)))
+(define (length+ x)                     ; Returns #f if X is circular.
+  ;; Try 21 times before checking for cicularities
+  (let loop ((x x)
+             (len 0))
+    (if (null? x)
+        len
+        (if (fx>? len 20)
+            ;; Tried 20 times, begin checking for circularities
+            (let lp ((x (cdr x)) (lag x) (len (fx+ len 1)))
+              (if (pair? x)
+                  (let ((x (cdr x))
+                        (len (fx+ len 1)))
+                    (if (pair? x)
+                        (let ((x   (cdr x))
+                              (lag (cdr lag))
+                              (len (fx+ len 1)))
+                          (and (not (eq? x lag)) (lp x lag len)))
+                        len))
+                  len))
+            ;; Still not 20 times
+            (loop (cdr x) (fx+ len 1))))))
 
 (define (zip list1 . more-lists) (apply map list list1 more-lists))
 
@@ -480,57 +505,57 @@
 ;;; take & drop
 
 (define (take lis k)
-  (check-arg integer? k take)
+  (check-arg fixnum? k take)
   (let recur ((lis lis) (k k))
     (if (zero? k) '()
-	(cons (car lis)
-	      (recur (cdr lis) (- k 1))))))
+        (cons (car lis)
+              (recur (cdr lis) (- k 1))))))
 
 (define (drop lis k)
-  (check-arg integer? k drop)
+  (check-arg fixnum? k drop)
   (let iter ((lis lis) (k k))
     (if (zero? k) lis (iter (cdr lis) (- k 1)))))
 
 (define (take! lis k)
-  (check-arg integer? k take!)
+  (check-arg fixnum? k take!)
   (if (zero? k) '()
       (begin (set-cdr! (drop lis (- k 1)) '())
-	     lis)))
+             lis)))
 
 ;;; TAKE-RIGHT and DROP-RIGHT work by getting two pointers into the list, 
 ;;; off by K, then chasing down the list until the lead pointer falls off
 ;;; the end.
 
 (define (take-right lis k)
-  (check-arg integer? k take-right)
+  (check-arg fixnum? k take-right)
   (let lp ((lag lis)  (lead (drop lis k)))
     (if (pair? lead)
-	(lp (cdr lag) (cdr lead))
-	lag)))
+        (lp (cdr lag) (cdr lead))
+        lag)))
 
 (define (drop-right lis k)
-  (check-arg integer? k drop-right)
+  (check-arg fixnum? k drop-right)
   (let recur ((lag lis) (lead (drop lis k)))
     (if (pair? lead)
-	(cons (car lag) (recur (cdr lag) (cdr lead)))
-	'())))
+        (cons (car lag) (recur (cdr lag) (cdr lead)))
+        '())))
 
 ;;; In this function, LEAD is actually K+1 ahead of LAG. This lets
 ;;; us stop LAG one step early, in time to smash its cdr to ().
 (define (drop-right! lis k)
-  (check-arg integer? k drop-right!)
+  (check-arg fixnum? k drop-right!)
   (let ((lead (drop lis k)))
     (if (pair? lead)
 
-	(let lp ((lag lis)  (lead (cdr lead)))	; Standard case
-	  (if (pair? lead)
-	      (lp (cdr lag) (cdr lead))
-	      (begin (set-cdr! lag '())
-		     lis)))
+        (let lp ((lag lis)  (lead (cdr lead)))  ; Standard case
+          (if (pair? lead)
+              (lp (cdr lag) (cdr lead))
+              (begin (set-cdr! lag '())
+                     lis)))
 
-	'())))	; Special case dropping everything -- no cons to side-effect.
+        '())))  ; Special case dropping everything -- no cons to side-effect.
 
-;(define (list-ref lis i) (car (drop lis i)))	; R4RS
+;(define (list-ref lis i) (car (drop lis i)))   ; R4RS
 
 ;;; These use the APL convention, whereby negative indices mean 
 ;;; "from the right." I liked them, but they didn't win over the
@@ -539,55 +564,55 @@
 ;;; K <= 0: Take and drop -K elts from the end   of the list.
 
 ;(define (take lis k)
-;  (check-arg integer? k take)
+;  (check-arg fixnum? k take)
 ;  (if (negative? k)
 ;      (list-tail lis (+ k (length lis)))
 ;      (let recur ((lis lis) (k k))
-;	(if (zero? k) '()
-;	    (cons (car lis)
-;		  (recur (cdr lis) (- k 1)))))))
+;       (if (zero? k) '()
+;           (cons (car lis)
+;                 (recur (cdr lis) (- k 1)))))))
 ;
 ;(define (drop lis k)
-;  (check-arg integer? k drop)
+;  (check-arg fixnum? k drop)
 ;  (if (negative? k)
 ;      (let recur ((lis lis) (nelts (+ k (length lis))))
-;	(if (zero? nelts) '()
-;	    (cons (car lis)
-;		  (recur (cdr lis) (- nelts 1)))))
+;       (if (zero? nelts) '()
+;           (cons (car lis)
+;                 (recur (cdr lis) (- nelts 1)))))
 ;      (list-tail lis k)))
 ;
 ;
 ;(define (take! lis k)
-;  (check-arg integer? k take!)
+;  (check-arg fixnum? k take!)
 ;  (cond ((zero? k) '())
-;	((positive? k)
-;	 (set-cdr! (list-tail lis (- k 1)) '())
-;	 lis)
-;	(else (list-tail lis (+ k (length lis))))))
+;       ((positive? k)
+;        (set-cdr! (list-tail lis (- k 1)) '())
+;        lis)
+;       (else (list-tail lis (+ k (length lis))))))
 ;
 ;(define (drop! lis k)
-;  (check-arg integer? k drop!)
+;  (check-arg fixnum? k drop!)
 ;  (if (negative? k)
 ;      (let ((nelts (+ k (length lis))))
-;	(if (zero? nelts) '()
-;	    (begin (set-cdr! (list-tail lis (- nelts 1)) '())
-;		   lis)))
+;       (if (zero? nelts) '()
+;           (begin (set-cdr! (list-tail lis (- nelts 1)) '())
+;                  lis)))
 ;      (list-tail lis k)))
 
 (define (split-at x k)
-  (check-arg integer? k split-at)
+  (check-arg fixnum? k split-at)
   (let recur ((lis x) (k k))
     (if (zero? k) (values '() lis)
-	(receive (prefix suffix) (recur (cdr lis) (- k 1))
-	  (values (cons (car lis) prefix) suffix)))))
+        (receive (prefix suffix) (recur (cdr lis) (- k 1))
+          (values (cons (car lis) prefix) suffix)))))
 
 (define (split-at! x k)
-  (check-arg integer? k split-at!)
+  (check-arg fixnum? k split-at!)
   (if (zero? k) (values '() x)
       (let* ((prev (drop x (- k 1)))
-	     (suffix (cdr prev)))
-	(set-cdr! prev '())
-	(values x suffix))))
+             (suffix (cdr prev)))
+        (set-cdr! prev '())
+        (values x suffix))))
 
 
 (define (last lis) (car (last-pair lis)))
@@ -606,64 +631,79 @@
 
 (define (unzip2 lis)
   (let recur ((lis lis))
-    (if (null-list? lis) (values lis lis)	; Use NOT-PAIR? to handle
-	(let ((elt (car lis)))			; dotted lists.
-	  (receive (a b) (recur (cdr lis))
-	    (values (cons (car  elt) a)
-		    (cons (cadr elt) b)))))))
+    (if (null-list? lis) (values lis lis)       ; Use NOT-PAIR? to handle
+        (let ((elt (car lis)))                  ; dotted lists.
+          (receive (a b) (recur (cdr lis))
+            (values (cons (car  elt) a)
+                    (cons (cadr elt) b)))))))
 
 (define (unzip3 lis)
   (let recur ((lis lis))
     (if (null-list? lis) (values lis lis lis)
-	(let ((elt (car lis)))
-	  (receive (a b c) (recur (cdr lis))
-	    (values (cons (car   elt) a)
-		    (cons (cadr  elt) b)
-		    (cons (caddr elt) c)))))))
+        (let ((elt (car lis)))
+          (receive (a b c) (recur (cdr lis))
+            (values (cons (car   elt) a)
+                    (cons (cadr  elt) b)
+                    (cons (caddr elt) c)))))))
 
 (define (unzip4 lis)
   (let recur ((lis lis))
     (if (null-list? lis) (values lis lis lis lis)
-	(let ((elt (car lis)))
-	  (receive (a b c d) (recur (cdr lis))
-	    (values (cons (car    elt) a)
-		    (cons (cadr   elt) b)
-		    (cons (caddr  elt) c)
-		    (cons (cadddr elt) d)))))))
+        (let ((elt (car lis)))
+          (receive (a b c d) (recur (cdr lis))
+            (values (cons (car    elt) a)
+                    (cons (cadr   elt) b)
+                    (cons (caddr  elt) c)
+                    (cons (cadddr elt) d)))))))
 
 (define (unzip5 lis)
   (let recur ((lis lis))
     (if (null-list? lis) (values lis lis lis lis lis)
-	(let ((elt (car lis)))
-	  (receive (a b c d e) (recur (cdr lis))
-	    (values (cons (car     elt) a)
-		    (cons (cadr    elt) b)
-		    (cons (caddr   elt) c)
-		    (cons (cadddr  elt) d)
-		    (cons (car (cddddr  elt)) e)))))))
+        (let ((elt (car lis)))
+          (receive (a b c d e) (recur (cdr lis))
+            (values (cons (car     elt) a)
+                    (cons (cadr    elt) b)
+                    (cons (caddr   elt) c)
+                    (cons (cadddr  elt) d)
+                    (cons (car (cddddr  elt)) e)))))))
 
 
 ;;; append! append-reverse append-reverse! concatenate concatenate!
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (append! . lists)
-  ;; First, scan through lists looking for a non-empty one.
-  (let lp ((lists lists) (prev '()))
-    (if (not (pair? lists)) prev
-	(let ((first (car lists))
-	      (rest (cdr lists)))
-	  (if (not (pair? first)) (lp rest first)
-
-	      ;; Now, do the splicing.
-	      (let lp2 ((tail-cons (last-pair first))
-			(rest rest))
-		(if (pair? rest)
-		    (let ((next (car rest))
-			  (rest (cdr rest)))
-		      (set-cdr! tail-cons next)
-		      (lp2 (if (pair? next) (last-pair next) tail-cons)
-			   rest))
-		    first)))))))
+(define append!
+  (case-lambda
+    (() '())
+    ;; Fast path 1
+    ((lis1) lis1)
+    ;; Fast path 2
+    ((lis1 lis2)
+     (cond
+      ((null? lis2) lis1)
+      ((null? lis1) lis2)
+      (else
+       (set-cdr! (last-pair lis1) lis2)
+       lis1)))
+    ;; N-ary case
+    ((lis1 lis2 lis3 . lists)
+     (let ((append-2! (lambda (lis1 lis2)
+                        (set-cdr! (last-pair lis1) lis2)
+                        lis1))
+           (lists (delete '() lists)))
+       (if (null? lists)
+           (if (null? lis3)
+               (append! lis1 lis2)
+               (let* ((lis (if (null? lis2) lis3 (append-2! lis2 lis3)))
+                      (lis (if (null? lis1) lis  (append-2! lis1 lis))))
+                 lis))
+           (let* ((lis (let loop ((lis (car lists))
+                                  (lists (cdr lists)))
+                         (if (null? lists) lis
+                             (append-2! lis (loop (car lists) (cdr lists))))))
+                  (lis (if (null? lis3) lis (append-2! lis3 lis)))
+                  (lis (if (null? lis2) lis (append-2! lis2 lis)))
+                  (lis (if (null? lis1) lis (append-2! lis1 lis))))
+             lis))))))
 
 ;;; APPEND is R4RS.
 ;(define (append . lists)
@@ -687,14 +727,14 @@
 (define (append-reverse rev-head tail)
   (let lp ((rev-head rev-head) (tail tail))
     (if (null-list? rev-head) tail
-	(lp (cdr rev-head) (cons (car rev-head) tail)))))
+        (lp (cdr rev-head) (cons (car rev-head) tail)))))
 
 (define (append-reverse! rev-head tail)
   (let lp ((rev-head rev-head) (tail tail))
     (if (null-list? rev-head) tail
-	(let ((next-rev (cdr rev-head)))
-	  (set-cdr! rev-head tail)
-	  (lp next-rev rev-head)))))
+        (let ((next-rev (cdr rev-head)))
+          (set-cdr! rev-head tail)
+          (lp next-rev rev-head)))))
 
 
 (define (concatenate  lists) (reduce-right append  '() lists))
@@ -713,18 +753,18 @@
 ;;; the needs of the fold/map procs -- for example, to minimize the number
 ;;; of times the argument lists need to be examined.
 
-;;; Return (map cdr lists). 
+;;; Return (map cdr lists).
 ;;; However, if any element of LISTS is empty, just abort and return '().
 (define (%cdrs lists)
-  (let f ((ls lists) (d* '()))
+  (let f ((ls lists))
     (if (pair? ls)
-      (let ((x (car ls)))
-        (if (null-list? x)
-          '()
-          (f (cdr ls) (cons (cdr x) d*))))
-      (reverse d*))))
+        (let ((x (car ls)))
+          (if (null? x)
+              '()
+              (cons (cdr x) (f (cdr ls)))))
+        '())))
 
-(define (%cars+ lists last-elt)	; (append! (map car lists) (list last-elt))
+(define (%cars+ lists last-elt) ; (append! (map car lists) (list last-elt))
   (let recur ((lists lists))
     (if (pair? lists) (cons (caar lists) (recur (cdr lists))) (list last-elt))))
 
@@ -733,138 +773,192 @@
 ;;; However, if any of the lists is empty, just abort and return [() ()].
 
 (define (%cars+cdrs lists)
-  (let f ((ls lists) (a* '()) (d* '()))
+  (let f ((ls lists))
     (if (pair? ls)
-      (let ((x (car ls)))
-        (if (null-list? x)
-          (values '() '())
-          (f (cdr ls) (cons (car x) a*) (cons (cdr x) d*))))
-      (values (reverse a*) (reverse d*)))))
+        (let ((x (car ls)))
+          (if (null-list? x)
+              (values '() '())
+              (receive (cars cdrs) (f (cdr ls))
+                (values (cons (car x) cars)
+                        (cons (cdr x) cdrs)))))
+        (values '() '()))))
 
 ;;; Like %CARS+CDRS, but we pass in a final elt tacked onto the end of the
 ;;; cars list. What a hack.
 (define (%cars+cdrs+ lists cars-final)
-  (let f ((ls lists) (a* '()) (d* '()))
+  (let f ((ls lists))
     (if (pair? ls)
-      (let ((x (car ls)))
-        (if (null-list? x)
-          (values '() '())
-          (f (cdr ls) (cons (car x) a*) (cons (cdr x) d*))))
-      (values (reverse (cons cars-final a*)) (reverse d*)))))
+        (let ((x (car ls)))
+          (if (null-list? x)
+              (values '() '())
+              (receive (cars cdrs) (f (cdr ls))
+                (values (cons (car x) cars)
+                        (cons (cdr x) cdrs)))))
+        (values (list cars-final) '()))))
 
 ;;; Like %CARS+CDRS, but blow up if any list is empty.
 (define (%cars+cdrs/no-test lists)
   (let recur ((lists lists))
     (if (pair? lists)
-	(receive (list other-lists) (car+cdr lists)
-	  (receive (a d) (car+cdr list)
-	    (receive (cars cdrs) (recur other-lists)
-	      (values (cons a cars) (cons d cdrs)))))
-	(values '() '()))))
+        (receive (list other-lists) (car+cdr lists)
+          (receive (a d) (car+cdr list)
+            (receive (cars cdrs) (recur other-lists)
+              (values (cons a cars) (cons d cdrs)))))
+        (values '() '()))))
 
 
 ;;; count
 ;;;;;;;;;
-(define (count pred list1 . lists)
-  (check-arg procedure? pred count)
-  (if (pair? lists)
-
-      ;; N-ary case
-      (let lp ((list1 list1) (lists lists) (i 0))
-	(if (null-list? list1) i
-	    (receive (as ds) (%cars+cdrs lists)
-	      (if (null? as) i
-		  (lp (cdr list1) ds
-		      (if (apply pred (car list1) as) (+ i 1) i))))))
-
-      ;; Fast path
-      (let lp ((lis list1) (i 0))
-	(if (null-list? lis) i
-	    (lp (cdr lis) (if (pred (car lis)) (+ i 1) i))))))
+(define count
+  (case-lambda
+    ;; Fast path
+    ((pred list1)
+     (check-arg procedure? pred count)
+     (let lp ((lis list1) (i 0))
+       (if (null-list? lis) i
+           (lp (cdr lis) (if (pred (car lis)) (fx+ i 1) i)))))
+    ;; N-ary case
+    ((pred list1 . lists)
+     (check-arg procedure? pred count)
+     (let lp ((list1 list1) (lists lists) (i 0))
+       (if (null-list? list1) i
+           (receive (as ds) (%cars+cdrs lists)
+             (if (null? as) i
+                 (lp (cdr list1) ds
+                     (if (apply pred (car list1) as) (fx+ i 1) i)))))))))
 
 
 ;;; fold/unfold
 ;;;;;;;;;;;;;;;
 
-(define (unfold-right p f g seed . maybe-tail)
-  (check-arg procedure? p unfold-right)
-  (check-arg procedure? f unfold-right)
-  (check-arg procedure? g unfold-right)
-  (let lp ((seed seed) (ans (:optional maybe-tail '())))
-    (if (p seed) ans
-	(lp (g seed)
-	    (cons (f seed) ans)))))
+(define unfold-right
+  (case-lambda
+    ((p f g seed)
+     (unfold-right p f g seed '()))
+    ((p f g seed tail)
+     (check-arg procedure? p unfold-right)
+     (check-arg procedure? f unfold-right)
+     (check-arg procedure? g unfold-right)
+     (let lp ((seed seed) (ans tail))
+       (if (p seed) ans
+           (lp (g seed)
+               (cons (f seed) ans)))))))
 
 
-(define (unfold p f g seed . maybe-tail-gen)
-  (check-arg procedure? p unfold)
-  (check-arg procedure? f unfold)
-  (check-arg procedure? g unfold)
-  (if (pair? maybe-tail-gen) ;;; so much for :optional (aghuloum)
-
-      (let ((tail-gen (car maybe-tail-gen)))
-	(if (pair? (cdr maybe-tail-gen))
-	    (apply error "Too many arguments" unfold p f g seed maybe-tail-gen)
-
-	    (let recur ((seed seed))
-	      (if (p seed) (tail-gen seed)
-		  (cons (f seed) (recur (g seed)))))))
-
-      (let recur ((seed seed))
-	(if (p seed) '()
-	    (cons (f seed) (recur (g seed)))))))
+(define unfold
+  (case-lambda
+    ((p f g seed)
+     (check-arg procedure? p unfold)
+     (check-arg procedure? f unfold)
+     (check-arg procedure? g unfold)
+     (let recur ((seed seed))
+        (if (p seed) '()
+            (cons (f seed) (recur (g seed))))))
+    ((p f g seed tail-gen)
+     (check-arg procedure? p unfold)
+     (check-arg procedure? f unfold)
+     (check-arg procedure? g unfold)
+     (let recur ((seed seed))
+       (if (p seed) (tail-gen seed)
+           (cons (f seed) (recur (g seed))))))))
       
 
-(define (fold kons knil lis1 . lists)
-  (check-arg procedure? kons fold)
-  (if (pair? lists)
-      (let lp ((lists (cons lis1 lists)) (ans knil))	; N-ary case
-	(receive (cars+ans cdrs) (%cars+cdrs+ lists ans)
-	  (if (null? cars+ans) ans ; Done.
-	      (lp cdrs (apply kons cars+ans)))))
-	    
-      (let lp ((lis lis1) (ans knil))			; Fast path
-	(if (null-list? lis) ans
-	    (lp (cdr lis) (kons (car lis) ans))))))
+(define fold
+  (case-lambda
+    ;; Fast path 1
+    ((kons knil lis1)
+     (check-arg procedure? kons fold)
+     (let lp ((lis lis1) (ans knil))
+       (if (null-list? lis) ans
+           (lp (cdr lis) (kons (car lis) ans)))))
+    ;; Fast path 2
+    ((kons knil lis1 lis2)
+     (check-arg procedure? kons fold)
+     (let lp ((lis1 lis1) (lis2 lis2) (ans knil))
+       (if (or (null-list? lis1) (null-list? lis2))
+           ans
+           (lp (cdr lis1) (cdr lis2) (kons (car lis1) (car lis2) ans)))))
+    ;; N-ary case
+    ((kons knil lis1 lis2 lis3 . lists)
+     (check-arg procedure? kons fold)
+     (let lp ((lis1 lis1) (lis2 lis2) (lis3 lis3)
+              (lists lists) (ans knil))
+       (if (or (null-list? lis1) (null-list? lis2) (null-list? lis3))
+           (receive (cars+ans cdrs) (%cars+cdrs+ lists ans)
+             (if (null? cars+ans)
+                 ans
+                 (lp (cdr lis1) (cdr lis2) (cdr lis3) cdrs
+                     (apply kons (car lis1) (car lis2) (car lis3) cars+ans)))))))))
 
 
-(define (fold-right kons knil lis1 . lists)
-  (check-arg procedure? kons fold-right)
-  (if (pair? lists)
-      (let recur ((lists (cons lis1 lists)))		; N-ary case
-	(let ((cdrs (%cdrs lists)))
-	  (if (null? cdrs) knil
-	      (apply kons (%cars+ lists (recur cdrs))))))
+(define fold-right
+  (case-lambda
+    ;; Fast path 1
+    ((kons knil lis1)
+     (check-arg procedure? kons fold-right)
+     (let recur ((lis lis1))
+       (if (null-list? lis) knil
+           (kons (car lis1) (recur (cdr lis))))))
+    ;; Fast path 2
+    ((kons knil lis1 lis2)
+     (check-arg procedure? kons fold-right)
+     (let recur ((lis1 lis1) (lis2 lis2))
+       (if (or (null-list? lis1) (null-list? lis2))
+           knil
+           (kons (car lis1) (car lis2) (recur (cdr lis1) (cdr lis2))))))
+    ;; N-ary case
+    ((kons knil lis1 lis2 lis3 . lists)
+     (check-arg procedure? kons fold-right)
+     (let recur ((lis1 lis1) (lis2 lis2) (lis3 lis3)
+                 (lists lists))
+       (if (or (null-list? lis1) (null-list? lis2) (null-list? lis3))
+           knil
+           (let ((cdrs (%cdrs lists)))
+             (if (null? cdrs) knil
+                 (apply kons (car lis1) (car lis2) (car lis3)
+                        (%cars+ lists (recur (cdr lis1) (cdr lis2) (cdr lis3)
+                                             cdrs))))))))))
 
-      (let recur ((lis lis1))				; Fast path
-	(if (null-list? lis) knil
-	    (let ((head (car lis)))
-	      (kons head (recur (cdr lis))))))))
 
+(define pair-fold-right
+  (case-lambda
+    ;; Fast path
+    ((f zero lis1)
+     (check-arg procedure? f pair-fold-right)
+     (let recur ((lis lis1))
+       (if (null-list? lis) zero (f lis (recur (cdr lis))))))
+    ;; N-ary case
+    ((f zero lis1 lis2 . lists)
+     (check-arg procedure? f pair-fold-right)
+     (let recur ((lis1 lis1) (lis2 lis2)
+                 (lists lists))
+       (if (or (null-list? lis1) (null-list? lis2))
+           zero
+           (let ((cdrs (%cdrs lists)))
+                (if (null? cdrs) zero
+                    (apply f lis1 lis2
+                           (append! lists (list (recur (cdr lis1) (cdr lis2) cdrs)))))))))))
 
-(define (pair-fold-right f zero lis1 . lists)
-  (check-arg procedure? f pair-fold-right)
-  (if (pair? lists)
-      (let recur ((lists (cons lis1 lists)))		; N-ary case
-	(let ((cdrs (%cdrs lists)))
-	  (if (null? cdrs) zero
-	      (apply f (append! lists (list (recur cdrs)))))))
-
-      (let recur ((lis lis1))				; Fast path
-	(if (null-list? lis) zero (f lis (recur (cdr lis)))))))
-
-(define (pair-fold f zero lis1 . lists)
-  (check-arg procedure? f pair-fold)
-  (if (pair? lists)
-      (let lp ((lists (cons lis1 lists)) (ans zero))	; N-ary case
-	(let ((tails (%cdrs lists)))
-	  (if (null? tails) ans
-	      (lp tails (apply f (append! lists (list ans)))))))
-
-      (let lp ((lis lis1) (ans zero))
-	(if (null-list? lis) ans
-	    (let ((tail (cdr lis)))		; Grab the cdr now,
-	      (lp tail (f lis ans)))))))	; in case F SET-CDR!s LIS.
+(define pair-fold
+  (case-lambda
+    ;; Fast path
+    ((f zero lis1)
+     (check-arg procedure? f pair-fold)
+     (let lp ((lis lis1) (ans zero))
+       (if (null? lis) ans
+           (let ((tail (cdr lis)))              ; Grab the cdr now,
+             (lp tail (f lis ans))))))
+    ;; N-ary case
+    ((f zero lis1 lis2 . lists)
+     (check-arg procedure? f pair-fold)
+     (let lp ((lis1 lis1) (lis2 lis2)
+              (lists lists) (ans zero))
+       (if (or (null-list? lis1) (null-list? lis2))
+           ans
+           (let ((tails (%cdrs lists)))
+                (if (null? tails) ans
+                     (lp (cdr lis1) (cdr lis2)
+                         tails (apply f lis1 lis2 (append! lists (list ans)))))))))))
       
 
 ;;; REDUCE and REDUCE-RIGHT only use RIDENTITY in the empty-list case.
@@ -879,132 +973,190 @@
   (check-arg procedure? f reduce-right)
   (if (null-list? lis) ridentity
       (let recur ((head (car lis)) (lis (cdr lis)))
-	(if (pair? lis)
-	    (f head (recur (car lis) (cdr lis)))
-	    head))))
+        (if (pair? lis)
+            (f head (recur (car lis) (cdr lis)))
+            head))))
 
 
 
 ;;; Mappers: append-map append-map! pair-for-each map! filter-map map-in-order
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (append-map f lis1 . lists)
-  (really-append-map append-map  append  f lis1 lists))
-(define (append-map! f lis1 . lists) 
-  (really-append-map append-map! append! f lis1 lists))
+(define append-map
+  (case-lambda
+    ((f lis1)
+     (really-append-map append-map  append  f lis1))
+    ((f lis1 lis2 . lists)
+     (really-append-map append-map  append  f lis1 lis2 lists))))
 
-(define (really-append-map who appender f lis1 lists)
-  (check-arg procedure? f who)
-  (if (pair? lists)
-      (receive (cars cdrs) (%cars+cdrs (cons lis1 lists))
-	(if (null? cars) '()
-	    (let recur ((cars cars) (cdrs cdrs))
-	      (let ((vals (apply f cars)))
-		(receive (cars2 cdrs2) (%cars+cdrs cdrs)
-		  (if (null? cars2) vals
-		      (appender vals (recur cars2 cdrs2))))))))
+(define append-map!
+  (case-lambda
+    ((f lis1)
+     (really-append-map append-map! append! f lis1))
+    ((f lis1 lis2 . lists)
+     (really-append-map append-map! append! f lis1 lis2 lists))))
 
-      ;; Fast path
-      (if (null-list? lis1) '()
-	  (let recur ((elt (car lis1)) (rest (cdr lis1)))
-	    (let ((vals (f elt)))
-	      (if (null-list? rest) vals
-		  (appender vals (recur (car rest) (cdr rest)))))))))
+(define really-append-map
+  (case-lambda
+    ;; Fast path
+    ((who appender f lis1)
+     (check-arg procedure? f who)
+     (if (null-list? lis1) '()
+         (let recur ((elt (car lis1)) (rest (cdr lis1)))
+           (let ((vals (f elt)))
+             (if (null-list? rest) vals
+                 (appender vals (recur (car rest) (cdr rest))))))))
+    ;; N-ary case
+    ((who appender f lis1 lis2 lists)
+     (check-arg procedure? f who)
+     (if (or (null-list? lis1) (null-list? lis2))
+         '()
+         (receive (cars cdrs) (%cars+cdrs lists)
+           (if (null? cars) '()
+               (let recur ((lis1 lis1) (lis2 lis2)
+                           (cars cars) (cdrs cdrs))
+                 (let ((vals (apply f (car lis1) (car lis2) cars))
+                       (lis1 (cdr lis1)) (lis2 (cdr lis2)))
+                   (if (or (null-list? lis1) (null-list? lis2))
+                       vals
+                       (receive (cars2 cdrs2) (%cars+cdrs cdrs)
+                         (if (null? cars2) vals
+                             (appender vals (recur lis1 lis2 cars2 cdrs2)))))))))))))
 
 
-(define (pair-for-each proc lis1 . lists)
-  (check-arg procedure? proc pair-for-each)
-  (if (pair? lists)
-
-      (let lp ((lists (cons lis1 lists)))
-	(let ((tails (%cdrs lists)))
-	  (if (pair? tails)
-	      (begin (apply proc lists)
-		     (lp tails)))))
-
-      ;; Fast path.
-      (let lp ((lis lis1))
-	(if (not (null-list? lis))
-	    (let ((tail (cdr lis)))	; Grab the cdr now,
-	      (proc lis)		; in case PROC SET-CDR!s LIS.
-	      (lp tail))))))
+(define pair-for-each
+  (case-lambda
+    ;; Fast path
+    ((proc lis1)
+     (check-arg procedure? proc pair-for-each)
+     (let lp ((lis lis1))
+        (if (not (null-list? lis))
+            (let ((tail (cdr lis)))     ; Grab the cdr now,
+              (proc lis)                ; in case PROC SET-CDR!s LIS.
+              (lp tail)))))
+    ;; N-ary case
+    ((proc lis1 lis2 . lists)
+     (check-arg procedure? proc pair-for-each)
+     (let lp ((lis1 lis1) (lis2 lis2)
+              (lists lists))
+       (if (and (pair? lis1) (pair? lis2))
+           (let ((tails (%cdrs lists)))
+                (if (pair? tails)
+                    (begin (apply proc lis1 lis2 lists)
+                           (lp (cdr lis1) (cdr lis2) tails)))))))))
 
 ;;; We stop when LIS1 runs out, not when any list runs out.
-(define (map! f lis1 . lists)
-  (check-arg procedure? f map!)
-  (if (pair? lists)
-      (let lp ((lis1 lis1) (lists lists))
-	(if (not (null-list? lis1))
-	    (receive (heads tails) (%cars+cdrs/no-test lists)
-	      (set-car! lis1 (apply f (car lis1) heads))
-	      (lp (cdr lis1) tails))))
-
-      ;; Fast path.
-      (pair-for-each (lambda (pair) (set-car! pair (f (car pair)))) lis1))
-  lis1)
+(define map!
+  (case-lambda
+    ;; Fast path 1
+    ((f lis1)
+     (check-arg procedure? f map!)
+     (let lp ((lis1 lis1))
+       (when (not (null-list? lis1))
+         (set-car! lis1 (f (car lis1)))
+         (lp (cdr lis1))))
+     lis1)
+    ;; Fast path 2
+    ((f lis1 lis2)
+     (check-arg procedure? f map!)
+     (let lp ((lis1 lis1) (lis2 lis2))
+       (when (not (null-list? lis1))
+         (set-car! lis1 (f (car lis1) (car lis2)))
+         (lp (cdr lis1) (cdr lis2))))
+     lis1)
+    ;; N-ary case
+    ((f lis1 lis2 lis3 . lists)
+     (check-arg procedure? f map!)
+     (let lp ((lis1 lis1) (lis2 lis2) (lis3 lis3) (lists lists))
+       (when (not (null-list? lis1))
+         (receive (heads tails) (%cars+cdrs/no-test lists)
+           (set-car! lis1 (apply f (car lis1) (car lis2) (car lis3) heads))
+           (lp (cdr lis1) (cdr lis2) (cdr lis3) tails))))
+     lis1)))
 
 
 ;;; Map F across L, and save up all the non-false results.
-(define (filter-map f lis1 . lists)
-  (check-arg procedure? f filter-map)
-  (if (pair? lists)
-      (let recur ((lists (cons lis1 lists)))
-	(receive (cars cdrs) (%cars+cdrs lists)
-	  (if (pair? cars)
-	      (cond ((apply f cars) => (lambda (x) (cons x (recur cdrs))))
-		    (else (recur cdrs))) ; Tail call in this arm.
-	      '())))
-	    
-      ;; Fast path.
-      (let recur ((lis lis1))
-	(if (null-list? lis) lis
-	    (let ((tail (recur (cdr lis))))
-	      (cond ((f (car lis)) => (lambda (x) (cons x tail)))
-		    (else tail)))))))
+(define filter-map
+  (case-lambda
+    ((f lis1)
+     (check-arg procedure? f filter-map)
+     (let recur ((lis lis1))
+       (if (null-list? lis) '()
+           (let ((tail (recur (cdr lis))))
+             (cond ((f (car lis)) => (lambda (x) (cons x tail)))
+                   (else tail))))))
+    ((f lis1 . lists)
+     (check-arg procedure? f filter-map)
+     (let recur ((lis1 lis1) (lists lists))
+       (if (null-list? lis1) '()
+           (receive (cars cdrs) (%cars+cdrs lists)
+             (if (pair? cars)
+                 (cond ((apply f (car lis1) cars)
+                        =>
+                        (lambda (x) (cons x (recur (cdr lis1) cdrs))))
+                       (else (recur (cdr lis1) cdrs))) ; Tail call in this arm.
+                 '())))))))
 
 
 ;;; Map F across lists, guaranteeing to go left-to-right.
 ;;; NOTE: Some implementations of R5RS MAP are compliant with this spec;
 ;;; in which case this procedure may simply be defined as a synonym for MAP.
 
-(define (map-in-order f lis1 . lists)
-  (check-arg procedure? f map-in-order)
-  (if (pair? lists)
-      (let recur ((lists (cons lis1 lists)))
-	(receive (cars cdrs) (%cars+cdrs lists)
-	  (if (pair? cars)
-	      (let ((x (apply f cars)))		; Do head first,
-		(cons x (recur cdrs)))		; then tail.
-	      '())))
-	    
-      ;; Fast path.
-      (let recur ((lis lis1))
-	(if (null-list? lis) lis
-	    (let ((tail (cdr lis))
-		  (x (f (car lis))))		; Do head first,
-	      (cons x (recur tail)))))))	; then tail.
+(define map-in-order
+  (case-lambda
+    ((f lis1)
+     (check-arg procedure? f map-in-order)
+     (let recur ((lis lis1))
+       (if (null-list? lis)
+           lis
+           (let ((tail (cdr lis))
+                 (x (f (car lis))))     ; Do head first,
+             (cons x (recur tail))))))  ; then tail
+    ((f lis1 lis2)
+     (check-arg procedure? f map-in-order)
+     (let recur ((lis1 lis1) (lis2 lis2))
+       (if (and (pair? lis1) (pair? lis2))
+           (let ((x (f (car lis1) (car lis2))))      ; Do head first,
+             (cons x (recur (cdr lis1) (cdr lis2)))) ; then tail.
+           '())))
+    ((f lis1 lis2 . lists)
+     (check-arg procedure? f map-in-order)
+     (let recur ((lis1 lis1) (lis2 lis2) (lists lists))
+       (receive (cars cdrs) (%cars+cdrs lists)
+         (if (and (pair? lis1) (pair? lis2) (pair? cars))
+             (let ((x (apply f (car lis1) (car lis2) cars))) ; Do head first,
+               (cons x (recur (cdr lis1) (cdr lis2) cdrs)))  ; then tail.
+             '()))))))
 
 
 ;;; We extend MAP to handle arguments of unequal length.
-(define map map-in-order)	
+(define map map-in-order)
 
 ;;; Contributed by Michael Sperber since it was missing from the
 ;;; reference implementation.
-(define (for-each f lis1 . lists)
-  (if (pair? lists)
-      (let recur ((lists (cons lis1 lists)))
-	(receive (cars cdrs) (%cars+cdrs lists)
-		 (if (pair? cars)
-		     (begin
-		       (apply f cars)	; Do head first,
-		       (recur cdrs)))))	; then tail.
-    
-      ;; Fast path.
-      (let recur ((lis lis1))
-	(if (not (null-list? lis))
-	    (begin
-	      (f (car lis))		; Do head first,
-	      (recur (cdr lis)))))))	; then tail.
+(define for-each
+  (case-lambda
+    ;; Fast path 1
+    ((f lis1)
+     (r6rs:for-each f lis1))
+    ;; Fast path 2
+    ((f lis1 lis2)
+     (check-arg procedure? f for-each)
+     (let recur ((lis1 lis1) (lis2 lis2))
+       (unless (or (null-list? lis1) (null-list? lis2))
+         (f (car lis1) (car lis2))
+         (recur (cdr lis1) (cdr lis2)))))
+    ;; N-ary case
+    ((f lis1 lis2 lis3 . lists)
+     (check-arg procedure? f for-each)
+     (let recur ((lis1 lis1) (lis2 lis2) (lis3 lis3)
+                 (lists lists))
+       (unless (or (null-list? lis1) (null-list? lis2) (null-list? lis3))
+         (receive (cars cdrs) (%cars+cdrs lists)
+           (when (pair? cars)
+             (apply f (car lis1) (car lis2) (car lis3) cars)      ; Do head first,
+             (recur (cdr lis1) (cdr lis2) (cdr lis3) cdrs)))))))) ; then tail.
+
 
 ;;; filter, remove, partition
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1014,17 +1166,17 @@
 ;; This FILTER shares the longest tail of L that has no deleted elements.
 ;; If Scheme had multi-continuation calls, they could be made more efficient.
 
-(define (filter pred lis)			; Sleazing with EQ? makes this
-  (check-arg procedure? pred filter)		; one faster.
-  (let recur ((lis lis))		
-    (if (null-list? lis) lis			; Use NOT-PAIR? to handle dotted lists.
-	(let ((head (car lis))
-	      (tail (cdr lis)))
-	  (if (pred head)
-	      (let ((new-tail (recur tail)))	; Replicate the RECUR call so
-		(if (eq? tail new-tail) lis
-		    (cons head new-tail)))
-	      (recur tail))))))			; this one can be a tail call.
+(define (filter pred lis)                       ; Sleazing with EQ? makes this
+  (check-arg procedure? pred filter)            ; one faster.
+  (let recur ((lis lis))
+    (if (null-list? lis) lis                    ; Use NOT-PAIR? to handle dotted lists.
+        (let ((head (car lis))
+              (tail (cdr lis)))
+          (if (pred head)
+              (let ((new-tail (recur tail)))    ; Replicate the RECUR call so
+                (if (eq? tail new-tail) lis
+                    (cons head new-tail)))
+              (recur tail))))))                 ; this one can be a tail call.
 
 
 ;;; Another version that shares longest tail.
@@ -1034,26 +1186,26 @@
 ;      ;; It also returns a flag NO-DEL? if the returned value
 ;      ;; is EQ? to L, i.e. if it didn't have to delete anything.
 ;      (let recur ((l l))
-;	(if (null-list? l) (values l #t)
-;	    (let ((x  (car l))
-;		  (tl (cdr l)))
-;	      (if (pred x)
-;		  (receive (ans no-del?) (recur tl)
-;		    (if no-del?
-;			(values l #t)
-;			(values (cons x ans) #f)))
-;		  (receive (ans no-del?) (recur tl) ; Delete X.
-;		    (values ans #f))))))
+;       (if (null-list? l) (values l #t)
+;           (let ((x  (car l))
+;                 (tl (cdr l)))
+;             (if (pred x)
+;                 (receive (ans no-del?) (recur tl)
+;                   (if no-del?
+;                       (values l #t)
+;                       (values (cons x ans) #f)))
+;                 (receive (ans no-del?) (recur tl) ; Delete X.
+;                   (values ans #f))))))
 ;    ans))
 
 
 
-;(define (filter! pred lis)			; Things are much simpler
-;  (let recur ((lis lis))			; if you are willing to
-;    (if (pair? lis)				; push N stack frames & do N
-;        (cond ((pred (car lis))		; SET-CDR! writes, where N is
+;(define (filter! pred lis)                     ; Things are much simpler
+;  (let recur ((lis lis))                       ; if you are willing to
+;    (if (pair? lis)                            ; push N stack frames & do N
+;        (cond ((pred (car lis))                ; SET-CDR! writes, where N is
 ;               (set-cdr! lis (recur (cdr lis))); the length of the answer.
-;               lis)				
+;               lis)
 ;              (else (recur (cdr lis))))
 ;        lis)))
 
@@ -1070,33 +1222,33 @@
 (define (filter! pred lis)
   (check-arg procedure? pred filter!)
   (let lp ((ans lis))
-    (cond ((null-list? ans)       ans)			; Scan looking for
-	  ((not (pred (car ans))) (lp (cdr ans)))	; first cons of result.
+    (cond ((null-list? ans)       ans)                  ; Scan looking for
+          ((not (pred (car ans))) (lp (cdr ans)))       ; first cons of result.
 
-	  ;; ANS is the eventual answer.
-	  ;; SCAN-IN: (CDR PREV) = LIS and (CAR PREV) satisfies PRED.
-	  ;;          Scan over a contiguous segment of the list that
-	  ;;          satisfies PRED.
-	  ;; SCAN-OUT: (CAR PREV) satisfies PRED. Scan over a contiguous
-	  ;;           segment of the list that *doesn't* satisfy PRED.
-	  ;;           When the segment ends, patch in a link from PREV
-	  ;;           to the start of the next good segment, and jump to
-	  ;;           SCAN-IN.
-	  (else (letrec ((scan-in (lambda (prev lis)
-				    (if (pair? lis)
-					(if (pred (car lis))
-					    (scan-in lis (cdr lis))
-					    (scan-out prev (cdr lis))))))
-			 (scan-out (lambda (prev lis)
-				     (let lp ((lis lis))
-				       (if (pair? lis)
-					   (if (pred (car lis))
-					       (begin (set-cdr! prev lis)
-						      (scan-in lis (cdr lis)))
-					       (lp (cdr lis)))
-					   (set-cdr! prev lis))))))
-		  (scan-in ans (cdr ans))
-		  ans)))))
+          ;; ANS is the eventual answer.
+          ;; SCAN-IN: (CDR PREV) = LIS and (CAR PREV) satisfies PRED.
+          ;;          Scan over a contiguous segment of the list that
+          ;;          satisfies PRED.
+          ;; SCAN-OUT: (CAR PREV) satisfies PRED. Scan over a contiguous
+          ;;           segment of the list that *doesn't* satisfy PRED.
+          ;;           When the segment ends, patch in a link from PREV
+          ;;           to the start of the next good segment, and jump to
+          ;;           SCAN-IN.
+          (else (letrec ((scan-in (lambda (prev lis)
+                                    (if (pair? lis)
+                                        (if (pred (car lis))
+                                            (scan-in lis (cdr lis))
+                                            (scan-out prev (cdr lis))))))
+                         (scan-out (lambda (prev lis)
+                                     (let lp ((lis lis))
+                                       (if (pair? lis)
+                                           (if (pred (car lis))
+                                               (begin (set-cdr! prev lis)
+                                                      (scan-in lis (cdr lis)))
+                                               (lp (cdr lis)))
+                                           (set-cdr! prev lis))))))
+                  (scan-in ans (cdr ans))
+                  ans)))))
 
 
 
@@ -1106,21 +1258,21 @@
 (define (partition pred lis)
   (check-arg procedure? pred partition)
   (let recur ((lis lis))
-    (if (null-list? lis) (values lis lis)	; Use NOT-PAIR? to handle dotted lists.
-	(let ((elt (car lis))
-	      (tail (cdr lis)))
-	  (receive (in out) (recur tail)
-	    (if (pred elt)
-		(values (if (pair? out) (cons elt in) lis) out)
-		(values in (if (pair? in) (cons elt out) lis))))))))
+    (if (null-list? lis) (values lis lis)       ; Use NOT-PAIR? to handle dotted lists.
+        (let ((elt (car lis))
+              (tail (cdr lis)))
+          (receive (in out) (recur tail)
+            (if (pred elt)
+                (values (if (pair? out) (cons elt in) lis) out)
+                (values in (if (pair? in) (cons elt out) lis))))))))
 
 
 
-;(define (partition! pred lis)			; Things are much simpler
-;  (let recur ((lis lis))			; if you are willing to
-;    (if (null-list? lis) (values lis lis)	; push N stack frames & do N
-;        (let ((elt (car lis)))			; SET-CDR! writes, where N is
-;          (receive (in out) (recur (cdr lis))	; the length of LIS.
+;(define (partition! pred lis)                  ; Things are much simpler
+;  (let recur ((lis lis))                       ; if you are willing to
+;    (if (null-list? lis) (values lis lis)      ; push N stack frames & do N
+;        (let ((elt (car lis)))                 ; SET-CDR! writes, where N is
+;          (receive (in out) (recur (cdr lis))  ; the length of LIS.
 ;            (cond ((pred elt)
 ;                   (set-cdr! lis in)
 ;                   (values lis out))
@@ -1146,44 +1298,80 @@
       ;;   SCAN-IN:  (cdr in-prev)  = LIS.
       ;;   SCAN-OUT: (cdr out-prev) = LIS.
       (letrec ((scan-in (lambda (in-prev out-prev lis)
-			  (let lp ((in-prev in-prev) (lis lis))
-			    (if (pair? lis)
-				(if (pred (car lis))
-				    (lp lis (cdr lis))
-				    (begin (set-cdr! out-prev lis)
-					   (scan-out in-prev lis (cdr lis))))
-				(set-cdr! out-prev lis))))) ; Done.
+                          (let lp ((in-prev in-prev) (lis lis))
+                            (if (pair? lis)
+                                (if (pred (car lis))
+                                    (lp lis (cdr lis))
+                                    (begin (set-cdr! out-prev lis)
+                                           (scan-out in-prev lis (cdr lis))))
+                                (set-cdr! out-prev lis))))) ; Done.
 
-	       (scan-out (lambda (in-prev out-prev lis)
-			   (let lp ((out-prev out-prev) (lis lis))
-			     (if (pair? lis)
-				 (if (pred (car lis))
-				     (begin (set-cdr! in-prev lis)
-					    (scan-in lis out-prev (cdr lis)))
-				     (lp lis (cdr lis)))
-				 (set-cdr! in-prev lis)))))) ; Done.
+               (scan-out (lambda (in-prev out-prev lis)
+                           (let lp ((out-prev out-prev) (lis lis))
+                             (if (pair? lis)
+                                 (if (pred (car lis))
+                                     (begin (set-cdr! in-prev lis)
+                                            (scan-in lis out-prev (cdr lis)))
+                                     (lp lis (cdr lis)))
+                                 (set-cdr! in-prev lis)))))) ; Done.
 
-	;; Crank up the scan&splice loops.
-	(if (pred (car lis))
-	    ;; LIS begins in-list. Search for out-list's first pair.
-	    (let lp ((prev-l lis) (l (cdr lis)))
-	      (cond ((not (pair? l)) (values lis l))
-		    ((pred (car l)) (lp l (cdr l)))
-		    (else (scan-out prev-l l (cdr l))
-			  (values lis l))))	; Done.
+        ;; Crank up the scan&splice loops.
+        (if (pred (car lis))
+            ;; LIS begins in-list. Search for out-list's first pair.
+            (let lp ((prev-l lis) (l (cdr lis)))
+              (cond ((not (pair? l)) (values lis l))
+                    ((pred (car l)) (lp l (cdr l)))
+                    (else (scan-out prev-l l (cdr l))
+                          (values lis l))))     ; Done.
 
-	    ;; LIS begins out-list. Search for in-list's first pair.
-	    (let lp ((prev-l lis) (l (cdr lis)))
-	      (cond ((not (pair? l)) (values l lis))
-		    ((pred (car l))
-		     (scan-in l prev-l (cdr l))
-		     (values l lis))		; Done.
-		    (else (lp l (cdr l)))))))))
+            ;; LIS begins out-list. Search for in-list's first pair.
+            (let lp ((prev-l lis) (l (cdr lis)))
+              (cond ((not (pair? l)) (values l lis))
+                    ((pred (car l))
+                     (scan-in l prev-l (cdr l))
+                     (values l lis))            ; Done.
+                    (else (lp l (cdr l)))))))))
 
+;; (define (remove pred l) (filter (lambda (x) (not (pred x))) l))
+;; (define (remove! pred l) (filter! (lambda (x) (not (pred x))) l))
 
-;;; Inline us, please.
-(define (remove  pred l) (filter  (lambda (x) (not (pred x))) l))
-(define (remove! pred l) (filter! (lambda (x) (not (pred x))) l))
+;; Avoid allocating a procedure
+;; Just a copy of filter with (pred head) <-> (not (pred head))
+(define (remove pred lis)
+  (check-arg procedure? pred remove)
+  (let recur ((lis lis))
+    (if (null-list? lis) lis
+        (let ((head (car lis))
+              (tail (cdr lis)))
+          (if (not (pred head))
+              (let ((new-tail (recur tail)))
+                (if (eq? tail new-tail) lis
+                    (cons head new-tail)))
+              (recur tail))))))
+
+;; Avoid allocating a procedure
+;; Just a copy of filter! with (pred head) <-> (not (pred head))
+(define (remove! pred lis)
+  (check-arg procedure? pred remove!)
+  (let lp ((ans lis))
+    (cond ((null-list? ans) ans)            ; Scan looking for
+          ((pred (car ans)) (lp (cdr ans))) ; first cons of result.
+
+          (else (letrec ((scan-in (lambda (prev lis)
+                                    (if (pair? lis)
+                                        (if (not (pred (car lis)))
+                                            (scan-in lis (cdr lis))
+                                            (scan-out prev (cdr lis))))))
+                         (scan-out (lambda (prev lis)
+                                     (let lp ((lis lis))
+                                       (if (pair? lis)
+                                           (if (not (pred (car lis)))
+                                               (begin (set-cdr! prev lis)
+                                                      (scan-in lis (cdr lis)))
+                                               (lp (cdr lis)))
+                                           (set-cdr! prev lis))))))
+                  (scan-in ans (cdr ans))
+                  ans)))))
 
 
 
@@ -1192,30 +1380,68 @@
 ;;; functions -- the procedural FILTER/REMOVE/FIND/FIND-TAIL variants
 ;;; are far more general.)
 ;;;
-;;; Function			Action
+;;; Function                    Action
 ;;; ---------------------------------------------------------------------------
-;;; remove pred lis		Delete by general predicate
-;;; delete x lis [=]		Delete by element comparison
-;;;					     
-;;; find pred lis		Search by general predicate
-;;; find-tail pred lis		Search by general predicate
-;;; member x lis [=]		Search by element comparison
+;;; remove pred lis             Delete by general predicate
+;;; delete x lis [=]            Delete by element comparison
 ;;;
-;;; assoc key lis [=]		Search alist by key comparison
-;;; alist-delete key alist [=]	Alist-delete by key comparison
+;;; find pred lis               Search by general predicate
+;;; find-tail pred lis          Search by general predicate
+;;; member x lis [=]            Search by element comparison
+;;;
+;;; assoc key lis [=]           Search alist by key comparison
+;;; alist-delete key alist [=]  Alist-delete by key comparison
 
-(define (delete x lis . maybe-=) 
-  (let ((= (:optional maybe-= equal?)))
-    (filter (lambda (y) (not (= x y))) lis)))
+(define delete
+  (case-lambda
+    ((x lis)
+     (delete x lis equal?))
+    ((x lis elt=)
+     (let recur ((lis lis))
+       (if (null-list? lis) lis
+           (let ((head (car lis))
+                 (tail (cdr lis)))
+             (if (not (elt= x head))
+                 (let ((new-tail (recur tail)))
+                   (if (eq? tail new-tail) lis
+                       (cons head new-tail)))
+                 (recur tail))))))))
 
-(define (delete! x lis . maybe-=)
-  (let ((= (:optional maybe-= equal?)))
-    (filter! (lambda (y) (not (= x y))) lis)))
+(define delete!
+  (case-lambda
+    ((x lis)
+     (delete! x lis equal?))
+    ((x lis elt=)
+     (let lp ((ans lis))
+       (cond ((null-list? ans)   ans)            ; Scan looking for
+             ((elt= x (car ans)) (lp (cdr ans))) ; first cons of result.
+
+             (else (letrec ((scan-in (lambda (prev lis)
+                                       (if (pair? lis)
+                                           (if (not (elt= x (car lis)))
+                                               (scan-in lis (cdr lis))
+                                               (scan-out prev (cdr lis))))))
+                            (scan-out (lambda (prev lis)
+                                        (let lp ((lis lis))
+                                          (if (pair? lis)
+                                              (if (not (elt= x (car lis)))
+                                                  (begin (set-cdr! prev lis)
+                                                         (scan-in lis (cdr lis)))
+                                                  (lp (cdr lis)))
+                                              (set-cdr! prev lis))))))
+                     (scan-in ans (cdr ans))
+                     ans)))))))
 
 ;;; Extended from R4RS to take an optional comparison argument.
-(define (member x lis . maybe-=)
-  (let ((= (:optional maybe-= equal?)))
-    (find-tail (lambda (y) (= x y)) lis)))
+(define member
+  (case-lambda
+    ((x lis)
+     (r6rs:member x lis))
+    ((x lis elt=)
+     (let lp ((lis lis))
+       (and (not (null-list? lis))
+            (if (elt= x (car lis)) lis
+                (lp (cdr lis))))))))
 
 ;;; R4RS, hence we don't bother to define.
 ;;; The MEMBER and then FIND-TAIL call should definitely
@@ -1233,36 +1459,50 @@
 ;;; linear-time algorithm to kill the dups. Or use an algorithm based on
 ;;; element-marking. The former gives you O(n lg n), the latter is linear.
 
-(define (delete-duplicates lis . maybe-=)
-  (let ((elt= (:optional maybe-= equal?)))
-    (check-arg procedure? elt= delete-duplicates)
-    (let recur ((lis lis))
-      (if (null-list? lis) lis
-	  (let* ((x (car lis))
-		 (tail (cdr lis))
-		 (new-tail (recur (delete x tail elt=))))
-	    (if (eq? tail new-tail) lis (cons x new-tail)))))))
+(define delete-duplicates
+  (case-lambda
+    ((lis)
+     (delete-duplicates lis equal?))
+    ((lis elt=)
+     (check-arg procedure? elt= delete-duplicates)
+     (let recur ((lis lis))
+       (if (null-list? lis) lis
+           (let* ((x (car lis))
+                  (tail (cdr lis))
+                  (new-tail (recur (delete x tail elt=))))
+             (if (eq? tail new-tail) lis (cons x new-tail))))))))
 
-(define (delete-duplicates! lis . maybe-=)
-  (let ((elt= (:optional maybe-= equal?)))
-    (check-arg procedure? elt= delete-duplicates!)
-    (let recur ((lis lis))
-      (if (null-list? lis) lis
-	  (let* ((x (car lis))
-		 (tail (cdr lis))
-		 (new-tail (recur (delete! x tail elt=))))
-	    (if (not (eq? tail new-tail))
-		(set-cdr! lis new-tail))
-	    lis)))))
+(define delete-duplicates!
+  (case-lambda
+    ((lis)
+     (delete-duplicates! lis equal?))
+    ((lis elt=)
+     (check-arg procedure? elt= delete-duplicates!)
+     (let recur ((lis lis))
+       (if (null-list? lis) lis
+           (let* ((x (car lis))
+                  (tail (cdr lis))
+                  (new-tail (recur (delete! x tail elt=))))
+             (if (not (eq? tail new-tail))
+                 (set-cdr! lis new-tail))
+             lis))))))
 
 
 ;;; alist stuff
 ;;;;;;;;;;;;;;;
 
 ;;; Extended from R4RS to take an optional comparison argument.
-(define (assoc x lis . maybe-=)
-  (let ((= (:optional maybe-= equal?)))
-    (find (lambda (entry) (= x (car entry))) lis)))
+(define assoc
+  (case-lambda
+    ((x lis)
+     (r6rs:assoc x lis))
+    ((x lis elt=)
+     (let loop ((lis lis))
+       (if (pair? lis)
+           (let ((entry (car lis)))
+             (if (elt= x (car entry)) entry
+                 (loop (cdr lis))))
+           #f)))))
 
 (define (alist-cons key datum alist) (cons (cons key datum) alist))
 
@@ -1270,150 +1510,245 @@
   (map (lambda (elt) (cons (car elt) (cdr elt)))
        alist))
 
-(define (alist-delete key alist . maybe-=)
-  (let ((= (:optional maybe-= equal?)))
-    (filter (lambda (elt) (not (= key (car elt)))) alist)))
+(define alist-delete
+  (case-lambda
+    ((key alist)
+     (remove (lambda (elt) (equal? key (car elt))) alist))
+    ((key alist elt=)
+     (remove (lambda (elt) (elt= key (car elt))) alist))))
 
-(define (alist-delete! key alist . maybe-=)
-  (let ((= (:optional maybe-= equal?)))
-    (filter! (lambda (elt) (not (= key (car elt)))) alist)))
+(define alist-delete!
+  (case-lambda
+    ((key alist)
+     (remove! (lambda (elt) (equal? key (car elt))) alist))
+    ((key alist elt=)
+     (remove! (lambda (elt) (elt= key (car elt))) alist))))
 
 
 ;;; find find-tail take-while drop-while span break any every list-index
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (find pred list)
-  (cond ((find-tail pred list) => car)
-	(else #f)))
+(define (find pred lis)
+  (check-arg procedure? pred find)
+  (let loop ((lis lis))
+    (if (pair? lis)
+        (let ((head (car lis)))
+          (if (pred head) head
+              (loop (cdr lis))))
+        #f)))
 
-(define (find-tail pred list)
+(define (find-tail pred lis)
   (check-arg procedure? pred find-tail)
-  (let lp ((list list))
-    (and (not (null-list? list))
-	 (if (pred (car list)) list
-	     (lp (cdr list))))))
+  (let lp ((lis lis))
+    (and (not (null-list? lis))
+         (if (pred (car lis)) lis
+             (lp (cdr lis))))))
 
 (define (take-while pred lis)
   (check-arg procedure? pred take-while)
   (let recur ((lis lis))
     (if (null-list? lis) '()
-	(let ((x (car lis)))
-	  (if (pred x)
-	      (cons x (recur (cdr lis)))
-	      '())))))
+        (let ((x (car lis)))
+          (if (pred x)
+              (cons x (recur (cdr lis)))
+              '())))))
 
 (define (drop-while pred lis)
   (check-arg procedure? pred drop-while)
   (let lp ((lis lis))
     (if (null-list? lis) '()
-	(if (pred (car lis))
-	    (lp (cdr lis))
-	    lis))))
+        (if (pred (car lis))
+            (lp (cdr lis))
+            lis))))
 
 (define (take-while! pred lis)
   (check-arg procedure? pred take-while!)
   (if (or (null-list? lis) (not (pred (car lis)))) '()
       (begin (let lp ((prev lis) (rest (cdr lis)))
-	       (if (pair? rest)
-		   (let ((x (car rest)))
-		     (if (pred x) (lp rest (cdr rest))
-			 (set-cdr! prev '())))))
-	     lis)))
+               (if (pair? rest)
+                   (let ((x (car rest)))
+                     (if (pred x) (lp rest (cdr rest))
+                         (set-cdr! prev '())))))
+             lis)))
 
 (define (span pred lis)
   (check-arg procedure? pred span)
   (let recur ((lis lis))
     (if (null-list? lis) (values '() '())
-	(let ((x (car lis)))
-	  (if (pred x)
-	      (receive (prefix suffix) (recur (cdr lis))
-		(values (cons x prefix) suffix))
-	      (values '() lis))))))
+        (let ((x (car lis)))
+          (if (pred x)
+              (receive (prefix suffix) (recur (cdr lis))
+                (values (cons x prefix) suffix))
+              (values '() lis))))))
 
 (define (span! pred lis)
   (check-arg procedure? pred span!)
   (if (or (null-list? lis) (not (pred (car lis)))) (values '() lis)
       (let ((suffix (let lp ((prev lis) (rest (cdr lis)))
-		      (if (null-list? rest) rest
-			  (let ((x (car rest)))
-			    (if (pred x) (lp rest (cdr rest))
-				(begin (set-cdr! prev '())
-				       rest)))))))
-	(values lis suffix))))
+                      (if (null-list? rest) rest
+                          (let ((x (car rest)))
+                            (if (pred x) (lp rest (cdr rest))
+                                (begin (set-cdr! prev '())
+                                       rest)))))))
+        (values lis suffix))))
   
 
-(define (break  pred lis) (span  (lambda (x) (not (pred x))) lis))
-(define (break! pred lis) (span! (lambda (x) (not (pred x))) lis))
+;; (define (break  pred lis) (span  (lambda (x) (not (pred x))) lis))
+;; (define (break! pred lis) (span! (lambda (x) (not (pred x))) lis))
 
-(define (any pred lis1 . lists)
-  (check-arg procedure? pred any)
-  (if (pair? lists)
+;; span with pred -> not pred
+(define (break pred lis)
+  (check-arg procedure? pred break)
+  (let recur ((lis lis))
+    (if (null-list? lis) (values '() '())
+        (let ((x (car lis)))
+          (if (not (pred x))
+              (receive (prefix suffix) (recur (cdr lis))
+                (values (cons x prefix) suffix))
+              (values '() lis))))))
 
-      ;; N-ary case
-      (receive (heads tails) (%cars+cdrs (cons lis1 lists))
-	(and (pair? heads)
-	     (let lp ((heads heads) (tails tails))
-	       (receive (next-heads next-tails) (%cars+cdrs tails)
-		 (if (pair? next-heads)
-		     (or (apply pred heads) (lp next-heads next-tails))
-		     (apply pred heads)))))) ; Last PRED app is tail call.
+;; span! with pred <-> not pred
+(define (break! pred lis)
+  (check-arg procedure? pred break!)
+  (if (or (null-list? lis) (pred (car lis))) (values '() lis)
+      (let ((suffix (let lp ((prev lis) (rest (cdr lis)))
+                      (if (null-list? rest) rest
+                          (let ((x (car rest)))
+                            (if (not (pred x)) (lp rest (cdr rest))
+                                (begin (set-cdr! prev '())
+                                       rest)))))))
+        (values lis suffix))))
 
-      ;; Fast path
-      (and (not (null-list? lis1))
-	   (let lp ((head (car lis1)) (tail (cdr lis1)))
-	     (if (null-list? tail)
-		 (pred head)		; Last PRED app is tail call.
-		 (or (pred head) (lp (car tail) (cdr tail))))))))
+(define any
+  (case-lambda
+    ;; Fast path 1
+    ((pred lis1)
+     (check-arg procedure? pred any)
+     (and (not (null-list? lis1))
+          (let loop ((head (car lis1)) (tail (cdr lis1)))
+            (if (null-list? tail)
+                (pred head)             ; Last PRED app is tail call.
+                (or (pred head) (loop (car tail) (cdr tail)))))))
+    ;; Fast path 2
+    ((pred lis1 lis2)
+     (check-arg procedure? pred any)
+     (and (not (null-list? lis1)) (not (null-list? lis2))
+          (let loop ((head1 (car lis1)) (tail1 (cdr lis1))
+                     (head2 (car lis2)) (tail2 (cdr lis2)))
+            (if (or (null-list? tail1) (null-list? tail2))
+                (pred head1 head2)      ; Last PRED app is tail call.
+                (or (pred head1 head2)
+                    (loop (car tail1) (cdr tail1)
+                          (car tail2) (cdr tail2)))))))
+    ;; N-ary case
+    ((pred lis1 lis2 . lists)
+     (check-arg procedure? pred any)
+     (and (not (null-list? lis1)) (not (null-list? lis2))
+          (receive (heads tails) (%cars+cdrs lists)
+            (and (pair? heads)
+                 (let loop ((head1 (car lis1)) (tail1 (cdr lis1))
+                            (head2 (car lis2)) (tail2 (cdr lis2))
+                            (heads heads) (tails tails))
+                   (if (or (null-list? tail1) (null-list? tail2))
+                       (apply pred head1 head2 heads)
+                                        ; Last PRED app is tail call.
+                       (receive (next-heads next-tails) (%cars+cdrs tails)
+                         (if (null? next-tails)
+                             (apply pred head1 head2 heads)
+                                        ; Last PRED app is tail call.
+                             (or (apply pred head1 head2 heads)
+                                 (loop (car tail1) (cdr tail1)
+                                       (car tail2) (cdr tail2)
+                                       next-heads next-tails))))))))))))
 
 
-;(define (every pred list)              ; Simple definition.
-;  (let lp ((list list))                ; Doesn't return the last PRED value.
-;    (or (not (pair? list))
-;        (and (pred (car list))
-;             (lp (cdr list))))))
+;;(define (every pred list)              ; Simple definition.
+;;  (let lp ((list list))                ; Doesn't return the last PRED value.
+;;    (or (not (pair? list))
+;;        (and (pred (car list))
+;;             (lp (cdr list))))))
 
-(define (every pred lis1 . lists)
-  (check-arg procedure? pred every)
-  (if (pair? lists)
+(define every
+  (case-lambda
+    ;; Fast path 1
+    ((pred lis1)
+     (check-arg procedure? pred every)
+     (or (null-list? lis1)
+         (let loop ((head (car lis1)) (tail (cdr lis1)))
+           (if (null-list? tail)
+               (pred head)              ; Last PRED app is tail call.
+               (and (pred head) (loop (car tail) (cdr tail)))))))
+    ;; Fast path 2
+    ((pred lis1 lis2)
+     (check-arg procedure? pred every)
+     (or (null-list? lis1) (null-list? lis2)
+         (let loop ((head1 (car lis1)) (tail1 (cdr lis1))
+                    (head2 (car lis2)) (tail2 (cdr lis2)))
+           (if (or (null-list? tail1) (null-list? tail2))
+               (pred head1 head2)       ; Last PRED app is tail call.
+               (and (pred head1 head2)
+                    (loop (car tail1) (cdr tail1)
+                          (car tail2) (cdr tail2)))))))
+    ;; N-ary case
+    ((pred lis1 lis2 . lists)
+     (check-arg procedure? pred every)
+     (or (null-list? lis1) (null-list? lis2)
+         (receive (heads tails) (%cars+cdrs lists)
+           (or (not (pair? heads))
+               (let loop ((head1 (car lis1)) (tail1 (cdr lis1))
+                          (head2 (car lis2)) (tail2 (cdr lis2))
+                          (heads heads) (tails tails))
+                 (if (or (null-list? tail1) (null-list? tail2))
+                     (apply pred head1 head2 heads)
+                                        ; Last PRED app is tail call.
+                     (receive (next-heads next-tails) (%cars+cdrs tails)
+                       (if (null? next-tails)
+                           (apply pred head1 head2 heads)
+                                        ; Last PRED app is tail call.
+                           (and (apply pred head1 head2 heads)
+                                (loop (car tail1) (cdr tail1)
+                                      (car tail2) (cdr tail2)
+                                      next-heads next-tails))))))))))))
 
-      ;; N-ary case
-      (receive (heads tails) (%cars+cdrs (cons lis1 lists))
-	(or (not (pair? heads))
-	    (let lp ((heads heads) (tails tails))
-	      (receive (next-heads next-tails) (%cars+cdrs tails)
-		(if (pair? next-heads)
-		    (and (apply pred heads) (lp next-heads next-tails))
-		    (apply pred heads)))))) ; Last PRED app is tail call.
-
-      ;; Fast path
-      (or (null-list? lis1)
-	  (let lp ((head (car lis1))  (tail (cdr lis1)))
-	    (if (null-list? tail)
-		(pred head)	; Last PRED app is tail call.
-		(and (pred head) (lp (car tail) (cdr tail))))))))
-
-(define (list-index pred lis1 . lists)
-  (check-arg procedure? pred list-index)
-  (if (pair? lists)
-
-      ;; N-ary case
-      (let lp ((lists (cons lis1 lists)) (n 0))
-	(receive (heads tails) (%cars+cdrs lists)
-	  (and (pair? heads)
-	       (if (apply pred heads) n
-		   (lp tails (+ n 1))))))
-
-      ;; Fast path
-      (let lp ((lis lis1) (n 0))
-	(and (not (null-list? lis))
-	     (if (pred (car lis)) n (lp (cdr lis) (+ n 1)))))))
+(define list-index
+  (case-lambda
+    ;; Fast path 1
+    ((pred lis1)
+     (check-arg procedure? pred list-index)
+     (let loop ((lis lis1)
+                (n 0))
+       (and (not (null-list? lis))
+            (if (pred (car lis)) n (loop (cdr lis) (fx+ n 1))))))
+    ;; Fast path 2
+    ((pred lis1 lis2)
+     (check-arg procedure? pred list-index)
+     (let loop ((lis1 lis1)
+                (lis2 lis2)
+                (n 0))
+       (and (not (or (null-list? lis1) (null-list? lis2)))
+            (if (pred (car lis1) (car lis2))
+                n
+                (loop (cdr lis1) (cdr lis2) (fx+ n 1))))))
+    ;; N-ary case
+    ((pred lis1 lis2 lis3 . lists)
+     (check-arg procedure? pred list-index)
+     (let loop ((lis1 lis1) (lis2 lis2) (lis3 lis3)
+                (lists lists)
+                (n 0))
+       (and (not (or (null-list? lis1) (null-list? lis2) (null-list? lis3)))
+            (receive (heads tails) (%cars+cdrs lists)
+              (and (not (null? heads))
+                   (if (apply pred (car lis1) (car lis2) (car lis3) heads)
+                       n
+                       (loop (cdr lis1) (cdr lis2) (cdr lis3) tails
+                             (fx+ n 1))))))))))
 
 ;;; Reverse
 ;;;;;;;;;;;
 
 ;R4RS, so not defined here.
 ;(define (reverse lis) (fold cons '() lis))
-				      
+
 ;(define (reverse! lis)
 ;  (pair-fold (lambda (pair tail) (set-cdr! pair tail) pair) '() lis))
 
@@ -1439,162 +1774,419 @@
 
 (define (%lset2<= = lis1 lis2) (every (lambda (x) (member x lis2 =)) lis1))
 
-(define (lset<= = . lists)
-  (check-arg procedure? = lset<=)
-  (or (not (pair? lists)) ; 0-ary case
-      (let lp ((s1 (car lists)) (rest (cdr lists)))
-	(or (not (pair? rest))
-	    (let ((s2 (car rest))  (rest (cdr rest)))
-	      (and (or (eq? s2 s1)	; Fast path
-		       (%lset2<= = s1 s2)) ; Real test
-		   (lp s2 rest)))))))
+(define lset<=
+  (case-lambda
+    ((=) (check-arg procedure? = lset<=) #t)
+    ((= lis1) (check-arg procedure? = lset<=) #t)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset<=)
+     (or (eq? lis1 lis2) (%lset2<= = lis1 lis2)))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset<=)
+     (and (or (eq? lis1 lis2) (%lset2<= = lis1 lis2))
+          (or (eq? lis2 lis3) (%lset2<= = lis2 lis3))
+          (or (null? lists)
+              (let loop ((lis1 lis3)
+                         (lis2 (car lists))
+                         (lists (cdr lists)))
+                (and (or (eq? lis1 lis2) (%lset2<= = lis1 lis2))
+                     (or (null? lists)
+                         (loop lis2 (car lists) (cdr lists))))))))))
 
-(define (lset= = . lists)
-  (check-arg procedure? = lset=)
-  (or (not (pair? lists)) ; 0-ary case
-      (let lp ((s1 (car lists)) (rest (cdr lists)))
-	(or (not (pair? rest))
-	    (let ((s2   (car rest))
-		  (rest (cdr rest)))
-	      (and (or (eq? s1 s2)	; Fast path
-		       (and (%lset2<= = s1 s2) (%lset2<= = s2 s1))) ; Real test
-		   (lp s2 rest)))))))
-
-
-(define (lset-adjoin = lis . elts)
-  (check-arg procedure? = lset-adjoin)
-  (fold (lambda (elt ans) (if (member elt ans =) ans (cons elt ans)))
-	lis elts))
-
-
-(define (lset-union = . lists)
-  (check-arg procedure? = lset-union)
-  (reduce (lambda (lis ans)		; Compute ANS + LIS.
-	    (cond ((null? lis) ans)	; Don't copy any lists
-		  ((null? ans) lis) 	; if we don't have to.
-		  ((eq? lis ans) ans)
-		  (else
-		   (fold (lambda (elt ans) (if (any (lambda (x) (= x elt)) ans)
-					       ans
-					       (cons elt ans)))
-			 ans lis))))
-	  '() lists))
-
-(define (lset-union! = . lists)
-  (check-arg procedure? = lset-union!)
-  (reduce (lambda (lis ans)		; Splice new elts of LIS onto the front of ANS.
-	    (cond ((null? lis) ans)	; Don't copy any lists
-		  ((null? ans) lis) 	; if we don't have to.
-		  ((eq? lis ans) ans)
-		  (else
-		   (pair-fold (lambda (pair ans)
-				(let ((elt (car pair)))
-				  (if (any (lambda (x) (= x elt)) ans)
-				      ans
-				      (begin (set-cdr! pair ans) pair))))
-			      ans lis))))
-	  '() lists))
+(define lset=
+  (case-lambda
+    ((=) (check-arg procedure? = lset=) #t)
+    ((= lis1) (check-arg procedure? = lset=) #t)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset=)
+     (or (eq? lis1 lis2)
+         (and (%lset2<= = lis1 lis2) (%lset2<= = lis2 lis1))))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset=)
+     (and (or (eq? lis1 lis2)
+              (and (%lset2<= = lis1 lis2) (%lset2<= = lis2 lis1)))
+          (or (eq? lis2 lis3)
+              (and (%lset2<= = lis2 lis3) (%lset2<= = lis3 lis2)))
+          (or (null? lists)
+              (let loop ((lis1 lis3)
+                         (lis2 (car lists))
+                         (lists (cdr lists)))
+                (and (or (eq? lis1 lis2)
+                         (and (%lset2<= = lis1 lis2) (%lset2<= = lis2 lis1)))
+                     (or (null? lists)
+                         (loop lis2 (car lists) (cdr lists))))))))))
 
 
-(define (lset-intersection = lis1 . lists)
-  (check-arg procedure? = lset-intersection)
-  (let ((lists (delete lis1 lists eq?))) ; Throw out any LIS1 vals.
-    (cond ((any null-list? lists) '())		; Short cut
-	  ((null? lists)          lis1)		; Short cut
-	  (else (filter (lambda (x)
-			  (every (lambda (lis) (member x lis =)) lists))
-			lis1)))))
-
-(define (lset-intersection! = lis1 . lists)
-  (check-arg procedure? = lset-intersection!)
-  (let ((lists (delete lis1 lists eq?))) ; Throw out any LIS1 vals.
-    (cond ((any null-list? lists) '())		; Short cut
-	  ((null? lists)          lis1)		; Short cut
-	  (else (filter! (lambda (x)
-			   (every (lambda (lis) (member x lis =)) lists))
-			 lis1)))))
-
-
-(define (lset-difference = lis1 . lists)
-  (check-arg procedure? = lset-difference)
-  (let ((lists (filter pair? lists)))	; Throw out empty lists.
-    (cond ((null? lists)     lis1)	; Short cut
-	  ((memq lis1 lists) '())	; Short cut
-	  (else (filter (lambda (x)
-			  (every (lambda (lis) (not (member x lis =)))
-				 lists))
-			lis1)))))
-
-(define (lset-difference! = lis1 . lists)
-  (check-arg procedure? = lset-difference!)
-  (let ((lists (filter pair? lists)))	; Throw out empty lists.
-    (cond ((null? lists)     lis1)	; Short cut
-	  ((memq lis1 lists) '())	; Short cut
-	  (else (filter! (lambda (x)
-			   (every (lambda (lis) (not (member x lis =)))
-				  lists))
-			 lis1)))))
+(define lset-adjoin
+  (case-lambda
+    ((= lis) lis)
+    ((= lis elt)
+     (check-arg procedure? = lset-adjoin)
+     (if (member elt lis) lis (cons elt lis)))
+    ((= lis elt1 elt2)
+     (check-arg procedure? = lset-adjoin)
+     (let* ((lis (if (member elt1 lis) lis (cons elt1 lis)))
+            (lis (if (member elt2 lis) lis (cons elt2 lis))))
+       lis))
+    ((= lis elt1 elt2 elt3 . elts)
+     (check-arg procedure? = lset-adjoin)
+     (let* ((lis (if (member elt1 lis) lis (cons elt1 lis)))
+            (lis (if (member elt2 lis) lis (cons elt2 lis)))
+            (lis (if (member elt3 lis) lis (cons elt3 lis))))
+       (if (null? elts) lis
+           (fold (lambda (elt ans) (if (member elt ans =) ans (cons elt ans)))
+                 lis elts))))))
 
 
-(define (lset-xor = . lists)
-  (check-arg procedure? = lset-xor)
-  (reduce (lambda (b a)			; Compute A xor B:
-	    ;; Note that this code relies on the constant-time
-	    ;; short-cuts provided by LSET-DIFF+INTERSECTION,
-	    ;; LSET-DIFFERENCE & APPEND to provide constant-time short
-	    ;; cuts for the cases A = (), B = (), and A eq? B. It takes
-	    ;; a careful case analysis to see it, but it's carefully
-	    ;; built in.
+(define lset-union
+  (let ((lset-union-2
+         (lambda (= lis1 lis2)
+           (cond ((null? lis1) lis2)    ; Don't copy any lists
+                 ((null? lis2) lis1)    ; if we don't have to.
+                 ((eq? lis1 lis2) lis1)
+                 (else
+                  (fold (lambda (elt ans)
+                          (if (member elt ans =)
+                              ans
+                              (cons elt ans)))
+                        lis1 lis2))))))
+    (case-lambda
+      ((=) (check-arg procedure? = lset-union) '())
+      ((= lis1) (check-arg procedure? = lset-union) lis1)
+      ((= lis1 lis2)
+       (check-arg procedure? = lset-union)
+       (lset-union-2 = lis1 lis2))
+      ((= lis1 lis2 lis3 . lists)
+       (check-arg procedure? = lset-union)
+       (let* ((lis (lset-union-2 = lis1 lis2))
+              (lis (lset-union-2 = lis  lis3)))
+         (if (null? lists) lis
+             (fold (lambda (lis2 lis1) (lset-union-2 = lis1 lis2))
+                   lis lists)))))))
 
-	    ;; Compute a-b and a^b, then compute b-(a^b) and
-	    ;; cons it onto the front of a-b.
-	    (receive (a-b a-int-b)   (lset-diff+intersection = a b)
-	      (cond ((null? a-b)     (lset-difference = b a))
-		    ((null? a-int-b) (append b a))
-		    (else (fold (lambda (xb ans)
-				  (if (member xb a-int-b =) ans (cons xb ans)))
-				a-b
-				b)))))
-	  '() lists))
+(define lset-union!
+  (let ((lset-union-2!
+         (lambda (= lis1 lis2)
+           (cond ((null? lis1) lis2)    ; Don't copy any lists
+                 ((null? lis2) lis1)    ; if we don't have to.
+                 ((eq? lis1 lis2) lis1)
+                 (else
+                  (pair-fold (lambda (pair ans)
+                               (let ((elt (car pair)))
+                                 (if (member elt ans =)
+                                     ans
+                                     (begin (set-cdr! pair ans) pair))))
+                             lis1 lis2))))))
+    (case-lambda
+      ((=)
+       (check-arg procedure? = lset-union!)
+       '())
+      ((= lis1) (check-arg procedure? = lset-union!) lis1)
+      ((= lis1 lis2) ; Splice new elts of LIS1 onto the front of LIS2.
+       (check-arg procedure? = lset-union!)
+       (lset-union-2! = lis1 lis2))
+      ((= lis1 lis2 lis3 . lists)
+       (check-arg procedure? = lset-union!)
+       (let* ((lis (lset-union-2! = lis1 lis2))
+              (lis (lset-union-2! = lis  lis3)))
+         (if (null? lists) lis
+             (fold (lambda (lis1 lis2) (lset-union-2! = lis1 lis2))
+                   lis lists)))))))
 
 
-(define (lset-xor! = . lists)
-  (check-arg procedure? = lset-xor!)
-  (reduce (lambda (b a)			; Compute A xor B:
-	    ;; Note that this code relies on the constant-time
-	    ;; short-cuts provided by LSET-DIFF+INTERSECTION,
-	    ;; LSET-DIFFERENCE & APPEND to provide constant-time short
-	    ;; cuts for the cases A = (), B = (), and A eq? B. It takes
-	    ;; a careful case analysis to see it, but it's carefully
-	    ;; built in.
+(define lset-intersection
+  (case-lambda
+    ((= lis1)
+     (check-arg procedure? = lset-intersection)
+     lis1)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-intersection)
+     (cond
+      ((or (null-list? lis1) (eq? lis1 lis2))
+       lis1)
+      ((null-list? lis2) lis2)
+      (else (filter (lambda (x) (member x lis2 =)) lis1))))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-intersection)
+     (cond
+      ;; Short cut
+      ((or (null-list? lis1) (null-list? lis2) (null-list? lis3)
+           (any null-list? lists))
+       '())
+      ;; Throw out lis2 (and lis3) if it is lis1
+      ((eq? lis2 lis1)
+       (if (eq? lis3 lis1)
+           (apply lset-intersection = lis1 lists)
+           (apply lset-intersection = lis1 lis3 lists)))
+      ;; Throw out lis3 if it is either lis1 or lis2
+      ((or (eq? lis3 lis1) (eq? lis3 lis2))
+       (apply lset-intersection = lis1 lis2 lists))
+      ;; Real procedure
+      (else
+       (let* ((lists (remove (lambda (lis)
+                               (or (eq? lis lis1) (eq? lis lis2) (eq? lis lis3)))
+                             lists)))
+         (filter (lambda (x)
+                   (and (member x lis2 =)
+                        (member x lis3 =)
+                        (every (lambda (lis) (member x lis =))
+                               lists)))
+                 lis1)))))))
 
-	    ;; Compute a-b and a^b, then compute b-(a^b) and
-	    ;; cons it onto the front of a-b.
-	    (receive (a-b a-int-b)   (lset-diff+intersection! = a b)
-	      (cond ((null? a-b)     (lset-difference! = b a))
-		    ((null? a-int-b) (append! b a))
-		    (else (pair-fold (lambda (b-pair ans)
-				       (if (member (car b-pair) a-int-b =) ans
-					   (begin (set-cdr! b-pair ans) b-pair)))
-				     a-b
-				     b)))))
-	  '() lists))
+(define lset-intersection!
+  (case-lambda
+    ((= lis1) (check-arg procedure? = lset-intersection!) lis1)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-intersection!)
+     (cond
+      ((or (null-list? lis2) (eq? lis1 lis2))
+       lis1)
+      ((null-list? lis1) lis2)
+      (else (filter! (lambda (x) (member x lis2 =)) lis1))))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-intersection!)
+     (cond
+      ;; Short cut
+      ((or (null-list? lis1) (null-list? lis2) (null-list? lis3)
+           (any null-list? lists))
+       '())
+      ;; Throw out lis2 (and lis3) if it is lis1
+      ((eq? lis2 lis1)
+       (if (eq? lis3 lis1)
+           (apply lset-intersection! = lis1 lists)
+           (apply lset-intersection! = lis1 lis3 lists)))
+      ;; Throw out lis3 if it is either lis1 or lis2
+      ((or (eq? lis3 lis1) (eq? lis3 lis2))
+       (apply lset-intersection! = lis1 lis2 lists))
+      ;; Real procedure
+      (else
+       (let ((lists (remove (lambda (lis)
+                              (or (eq? lis lis1) (eq? lis lis2) (eq? lis lis3)))
+                            lists)))    ; Remove duplicates
+         (filter! (lambda (x)
+                    (and (member x lis2 =)
+                         (member x lis3 =)
+                         (every (lambda (lis) (member x lis =))
+                                lists)))
+                  lis1)))))))
 
 
-(define (lset-diff+intersection = lis1 . lists)
-  (check-arg procedure? = lset-diff+intersection)
-  (cond ((every null-list? lists) (values lis1 '()))	; Short cut
-	((memq lis1 lists)        (values '() lis1))	; Short cut
-	(else (partition (lambda (elt)
-			   (not (any (lambda (lis) (member elt lis =))
-				     lists)))
-			 lis1))))
+(define lset-difference
+  (case-lambda
+    ((= lis1) (check-arg procedure? = lset-difference) lis1)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-difference)
+     (cond
+      ((null-list? lis2) lis1)
+      ((or (null-list? lis1) (eq? lis1 lis2))
+       '())
+      (else (filter (lambda (x) (not (member x lis2 =))) lis1))))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-difference)
+     (cond
+      ;; Short cut
+      ((or (null-list? lis1) (eq? lis1 lis2) (eq? lis1 lis3)
+           (memq lis1 lists))
+       '())
+      ;; Throw out lis2 (or lis3) if it is nil
+      ((null? lis2)
+       (if (null? lis3)
+           (apply lset-difference lis1 lists)
+           (apply lset-difference lis1 lis3 lists)))
+      ;; Throw out lis3 if it is lis2 or nil
+      ((or (null? lis3) (eq? lis3 lis2))
+       (apply lset-difference lis1 lis2 lists))
+      ;; Real procedure
+      (else
+       (let ((lists (remove (lambda (lis)
+                              (or (null? lis) (eq? lis lis2) (eq? lis lis3)))
+                            lists))) ; Remove nil, lis2 and lis3
+         (filter (lambda (x)
+                   (and (not (member x lis2 =))
+                        (not (member x lis3 =))
+                        (every (lambda (lis) (not (member x lis =)))
+                               lists)))
+                 lis1)))))))
 
-(define (lset-diff+intersection! = lis1 . lists)
-  (check-arg procedure? = lset-diff+intersection!)
-  (cond ((every null-list? lists) (values lis1 '()))	; Short cut
-	((memq lis1 lists)        (values '() lis1))	; Short cut
-	(else (partition! (lambda (elt)
-			    (not (any (lambda (lis) (member elt lis =))
-				      lists)))
-			  lis1))))
+(define lset-difference!
+  (case-lambda
+    ((= lis1) (check-arg procedure? = lset-difference!) lis1)
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-difference!)
+     (cond
+      ((null-list? lis2) lis1)
+      ((or (null-list? lis1) (eq? lis1 lis2))
+       '())
+      (else (filter! (lambda (x) (not (member x lis2 =))) lis1))))
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-difference!)
+     (cond
+      ;; Short cut
+      ((or (null-list? lis1) (eq? lis1 lis2) (eq? lis1 lis3)
+           (memq lis1 lists))
+       '())
+      ;; Throw out lis2 (or lis3) if it is nil
+      ((null? lis2)
+       (if (null? lis3)
+           (apply lset-difference lis1 lists)
+           (apply lset-difference lis1 lis3 lists)))
+      ;; Throw out lis3 if it is lis2 or nil
+      ((or (null? lis3) (eq? lis3 lis2))
+       (apply lset-difference lis1 lis2 lists))
+      ;; Real procedure
+      (else
+       (let ((lists (remove (lambda (lis)
+                              (or (null? lis) (eq? lis lis2) (eq? lis lis3)))
+                            lists))) ; Remove nil, lis2 and lis3
+         (filter! (lambda (x)
+                    (and (not (member x lis2 =))
+                         (every (lambda (lis) (not (member x lis =)))
+                                lists)))
+                  lis1)))))))
+
+
+(define lset-xor
+  (let ((lset-xor-2
+         (lambda (= b a)                ; Compute A xor B:
+           ;; Note that this code relies on the constant-time
+           ;; short-cuts provided by LSET-DIFF+INTERSECTION,
+           ;; LSET-DIFFERENCE & APPEND to provide constant-time short
+           ;; cuts for the cases A = (), B = (), and A eq? B. It takes
+           ;; a careful case analysis to see it, but it's carefully
+           ;; built in.
+
+           ;; Compute a-b and a^b, then compute b-(a^b) and
+           ;; cons it onto the front of a-b.
+           (receive (a-b a-int-b)   (lset-diff+intersection = a b)
+             (cond ((null? a-b)     (lset-difference = b a))
+                   ((null? a-int-b) (append b a))
+                   (else (fold (lambda (xb ans)
+                                 (if (member xb a-int-b =) ans (cons xb ans)))
+                               a-b
+                               b)))))))
+    (case-lambda
+      ((=) (check-arg procedure? = lset-xor) '())
+      ((= a) (check-arg procedure? = lset-xor) a)
+      ((= a b)
+       (check-arg procedure? = lset-xor)
+       (lset-xor-2 = b a))
+      ((= a b c . lists)
+       (check-arg procedure? = lset-xor)
+       (let* ((lis (lset-xor-2 = b a))
+              (lis (lset-xor-2 = c lis)))
+         (if (null? lists) lis
+             (fold (lambda (b a) (lset-xor-2 = b a))
+                   lis lists)))))))
+
+(define lset-xor!
+  (let ((lset-xor-2!
+         (lambda (= b a)                ; Compute A xor B:
+           ;; Note that this code relies on the constant-time
+           ;; short-cuts provided by LSET-DIFF+INTERSECTION,
+           ;; LSET-DIFFERENCE & APPEND to provide constant-time short
+           ;; cuts for the cases A = (), B = (), and A eq? B. It takes
+           ;; a careful case analysis to see it, but it's carefully
+           ;; built in.
+
+           ;; Compute a-b and a^b, then compute b-(a^b) and
+           ;; cons it onto the front of a-b.
+           (receive (a-b a-int-b)   (lset-diff+intersection! = a b)
+             (cond ((null? a-b)     (lset-difference! = b a))
+                   ((null? a-int-b) (append! b a))
+                   (else (pair-fold (lambda (b-pair ans)
+                                      (if (member (car b-pair) a-int-b =) ans
+                                          (begin (set-cdr! b-pair ans) b-pair)))
+                                    a-b
+                                    b)))))))
+    (case-lambda
+      ((=) (check-arg procedure? = lset-xor!) '())
+      ((= a) (check-arg procedure? = lset-xor!) a)
+      ((= a b)
+       (check-arg procedure? = lset-xor!)
+       (lset-xor-2! = b a))
+      ((= a b c . lists)
+       (check-arg procedure? = lset-xor!)
+       (let* ((lis (lset-xor-2! = b a))
+              (lis (lset-xor-2! = c lis)))
+         (if (null? lists) lis
+             (fold (lambda (b a) (lset-xor-2! = b a))
+                   lis lists)))))))
+
+
+(define lset-diff+intersection
+  (case-lambda
+    ;; Fast path 1
+    ((= lis1)
+     (check-arg procedure? = lset-diff+intersection)
+     (values lis1 '()))
+    ;; Fast path 2
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-diff+intersection)
+     (cond
+      ((or (null-list? lis1) (eq? lis1 lis2)) (values '() lis1))
+      ((null-list? lis2) (values lis1 '()))
+      (else (partition (lambda (elt)
+                         (not (member elt lis2 =)))
+                       lis1))))
+    ;; N-ary case
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-diff+intersection)
+     (cond
+      ((or (null-list? lis1) (eq? lis1 lis2) (eq? lis1 lis3)
+           (memq lis1 lists))
+       (values '() lis1))
+      ((null-list? lis2)
+       (if (null-list? lis3)
+           (apply lset-diff+intersection = lis1 lists)
+           (apply lset-diff+intersection = lis1 lis3 lists)))
+      ((or (null-list? lis3) (eq? lis3 lis2))
+       (apply lset-diff+intersection = lis1 lis2 lists))
+      (else
+       (let ((lists (remove (lambda (lis)
+                              (or (null? lis) (eq? lis lis2) (eq? lis lis3)))
+                            lists)))
+         (partition (lambda (elt)
+                      (not (or (member elt lis2 =)
+                               (member elt lis3 =)
+                               (any (lambda (lis) (member elt lis =))
+                                    lists))))
+                    lis1)))))))
+
+(define lset-diff+intersection!
+  (case-lambda
+    ;; Fast path 1
+    ((= lis1)
+     (check-arg procedure? = lset-diff+intersection!)
+     (values lis1 '()))
+    ;; Fast path 2
+    ((= lis1 lis2)
+     (check-arg procedure? = lset-diff+intersection!)
+     (cond
+      ((or (null-list? lis1) (eq? lis1 lis2)) (values '() lis1))
+      ((null-list? lis2) (values lis1 '()))
+      (else (partition! (lambda (elt)
+                          (not (member elt lis2 =)))
+                        lis1))))
+    ;; N-ary case
+    ((= lis1 lis2 lis3 . lists)
+     (check-arg procedure? = lset-diff+intersection!)
+     (cond
+      ((or (null-list? lis1) (eq? lis1 lis2) (eq? lis1 lis3)
+           (memq lis1 lists))
+       (values '() lis1))
+      ((null-list? lis2)
+       (if (null-list? lis3)
+           (apply lset-diff+intersection! = lis1 lists)
+           (apply lset-diff+intersection! = lis1 lis3 lists)))
+      ((or (null-list? lis3) (eq? lis3 lis2))
+       (apply lset-diff+intersection = lis1 lis2 lists))
+      (else
+       (let ((lists (remove (lambda (lis)
+                              (or (null? lis) (eq? lis lis2) (eq? lis lis3)))
+                            lists)))
+         (partition! (lambda (elt)
+                       (not (or (member elt lis2 =)
+                                (member elt lis3 =)
+                                (any (lambda (lis) (member elt lis =))
+                                     lists))))
+                     lis1)))))))

--- a/tests/lists.sps
+++ b/tests/lists.sps
@@ -14,10 +14,11 @@
 ; that the cells of the results are the cells of the input with only
 ; the CDR changed, ie, values are never moved from one cell to another.
 
-(import (except (rnrs base) map for-each)
+(import (except (rnrs base) error map for-each)
         (rnrs io simple)
         (rnrs r5rs)
-        (srfi :1 lists))
+        (srfi :1 lists)
+        (srfi :23 error))
 
 (define (writeln . xs)
   (for-each display xs)


### PR DESCRIPTION
I've made many optimizations in (srfi :1), specially for handling optional arguments (now the code uses case-lambda, which is much more transparent and can be optimized by the implementation). Uses R6RS for for-each when iterating over only one list, also use R6RS member and assoc when comparison argument is omitted. Avoids consing and reversing recently built lists (instead, build it in the right order).

All tests pass in Chez Scheme. There is no implementation-specific code, but I'll test it on other implementations as well.

BTW I intend to work on this library, specially (srfi 128) (the hashing needs to be improved), (srfi 144) and (srfi 152) (the latter is part of R7RS Red Edition).