### PR TITLE
SRFI-26: Define auxiliary syntax with a standard define-syntax

### DIFF
--- a/%3a26/cut.scm
+++ b/%3a26/cut.scm
@@ -85,10 +85,12 @@
 
 ; exported syntax
 
-(define-syntax (<> x)
-  (syntax-violation #f "misplaced aux keyword <>"))
-(define-syntax (<...> x)
-  (syntax-violation #f "misplaced aux keyword <...>"))
+(define-syntax <>
+  (lambda (x)
+    (syntax-violation #f "misplaced aux keyword <>")))
+(define-syntax <...>
+  (lambda (x)
+    (syntax-violation #f "misplaced aux keyword <...>")))
 
 (define-syntax cut
   (syntax-rules ()


### PR DESCRIPTION
This fixes SRFI-26 for Schemes that don't support the shorthand define-syntax notation.