### PR TITLE
fix srfi 143

### DIFF
--- a/%3a143/fixnums.sls
+++ b/%3a143/fixnums.sls
@@ -12,7 +12,7 @@
     fxnot fxand fxior fxxor fxarithmetic-shift fxarithmetic-shift-left
     fxarithmetic-shift-right fxbit-count fxlength fxif fxbit-set? fxcopy-bit
     fxfirst-set-bit fxbit-field fxbit-field-rotate fxbit-field-reverse)
-  (import (rnrs) (srfi :143 fixnums helpers))
+  (import (rnrs) (srfi :143 helpers))
 
   (define fx-width (fixnum-width))
   (define fx-greatest (greatest-fixnum))

--- a/%3a143/helpers.chezscheme.sls
+++ b/%3a143/helpers.chezscheme.sls
@@ -1,3 +1,3 @@
-(library (srfi :143 fixnums helpers)
+(library (srfi :143 helpers)
   (export fxabs fxremainder fxquotient)
   (import (chezscheme)))

--- a/%3a143/helpers.sls
+++ b/%3a143/helpers.sls
@@ -1,4 +1,4 @@
-(library (srfi :143 fixnums helpers)
+(library (srfi :143 helpers)
   (export fxabs fxremainder fxquotient)
   (import (rnrs) (rnrs r5rs))
 


### PR DESCRIPTION
`helpers.sls` was referenced as `(:143 fixnums helpers)` instead of `(:143 helpers)`