### PR TITLE
Compatibility libraries for Vicare and Sagittarius

### DIFF
--- a/private/include/compat.sagittarius.sls
+++ b/private/include/compat.sagittarius.sls
@@ -1,0 +1,9 @@
+#!r6rs
+;; Copyright 2010 Derick Eddington.  My MIT-style license is in the file named
+;; LICENSE from the original collection this file is distributed with.
+
+(library (srfi private include compat)
+  (export
+    (rename (load-path search-paths)))
+  (import
+    (only (sagittarius) load-path)))

--- a/private/include/compat.vicare.sls
+++ b/private/include/compat.vicare.sls
@@ -1,0 +1,9 @@
+#!r6rs
+;; Copyright 2010 Derick Eddington.  My MIT-style license is in the file named
+;; LICENSE from the original collection this file is distributed with.
+
+(library (srfi private include compat)
+  (export
+    (rename (library-source-search-path search-paths)))
+  (import
+    (only (vicare libraries) library-source-search-path)))


### PR DESCRIPTION
This adds `(srfi private include compat)` for Vicare and Sagittarius.