### PR TITLE
Compatibility libraries for Loko Scheme

### DIFF
--- a/%3a19/time/compat.loko.sls
+++ b/%3a19/time/compat.loko.sls
@@ -1,0 +1,30 @@
+;; Copyright © 2019 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+(library (srfi :19 time compat)
+  (export
+    time-resolution
+    timezone-offset
+    current-time
+    cumulative-thread-time
+    cumulative-process-time
+    cumulative-gc-time
+    time-nanosecond
+    time-second)
+  (import
+    (rnrs)
+    (except (loko system time) time-resolution)
+    (prefix (only (loko system time) time-resolution)
+            loko:))
+
+  (define time-resolution (loko:time-resolution (current-time)))
+
+  (define (cumulative-thread-time)
+    (error 'cumulative-thread-time "not implemented"))
+
+  (define (cumulative-gc-time)
+    (error 'cumulative-gc-time "not implemented"))
+
+  ;; Loko currently doesn't parse the timezone database
+  (define timezone-offset 0))

--- a/%3a6/basic-string-ports/compat.loko.sls
+++ b/%3a6/basic-string-ports/compat.loko.sls
@@ -1,0 +1,7 @@
+;; Copyright © 2019 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+(library (srfi :6 basic-string-ports compat)
+  (export open-output-string get-output-string)
+  (import (only (loko) open-output-string get-output-string)))

--- a/private/include/compat.loko.sls
+++ b/private/include/compat.loko.sls
@@ -1,0 +1,7 @@
+;; Copyright © 2019 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+(library (srfi private include compat)
+  (export (rename (library-directories search-paths)))
+  (import (only (loko) library-directories)))

--- a/private/platform-features.loko.sls
+++ b/private/platform-features.loko.sls
@@ -1,0 +1,24 @@
+;; Copyright © 2019 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+(library (srfi private platform-features)
+  (export
+    expand-time-features
+    run-time-features)
+  (import
+    (rnrs base)
+    (rnrs lists)
+    (loko))
+
+  (define (expand-time-features)
+    '(loko syntax-case))
+
+  (define (run-time-features)
+    (let ((mt (machine-type)))
+      (append (case (vector-ref mt 0)
+                ((amd64) '(x86-64))
+                (else '()))
+              (case (vector-ref mt 1)
+                ((linux) '(linux posix))
+                (else '()))))))


### PR DESCRIPTION
This adds basic compatibility libraries for [Loko Scheme](https://scheme.fail/).