### PR TITLE
Add read library to allow one to use something better than just read

### DIFF
--- a/private/include.sls
+++ b/private/include.sls
@@ -6,8 +6,9 @@
   (export 
     include/resolve)
   (import 
-    (rnrs) 
-    (for (srfi private include compat) expand))
+    (except (rnrs) read)
+    (for (srfi private include compat) expand)
+    (for (srfi private include read) expand))
   
   (define-syntax include/resolve
     (lambda (stx)

--- a/private/include/read.ironscheme.sls
+++ b/private/include/read.ironscheme.sls
@@ -1,0 +1,8 @@
+#!r6rs
+
+(library (srfi private include read)
+  (export
+    (rename (read-annotated read)))
+  (import
+    (only (ironscheme reader) read-annotated))
+)

--- a/private/include/read.sls
+++ b/private/include/read.sls
@@ -1,0 +1,8 @@
+#!r6rs
+;; Copyright 2019 Derick Eddington.  My MIT-style license is in the file named
+;; LICENSE from the original collection this file is distributed with.
+
+(library (srfi private include read)
+  (export read)
+  (import (only (rnrs) read))
+)


### PR DESCRIPTION
I know quite a few Schemes have a better `read` eg `annotated-read`, these files just allows you to use that, which helps in turn for error reporting, debugging and editor support.