### PR TITLE
Use a free software implementation of SRFI 5 and add tests

### DIFF
--- a/%3a5/let.sls
+++ b/%3a5/let.sls
@@ -1,89 +1,38 @@
+;; Copyright © 2020 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+;; SRFI 5: let form with define-style syntax and rest arguments
+
 (library (srfi :5 let)
   (export let)
-  (import (rename (rnrs) (let standard-let)))
+  (import (rename (rnrs) (let rnrs:let)))
 
-  ;; Reference implmentation from the SRFI document:
-
-  ;; Copyright (C) Andy Gaynor (1999). All Rights Reserved.
-  ;; 
-  ;; This document and translations of it may be copied and furnished to
-  ;; others, and derivative works that comment on or otherwise explain it or
-  ;; assist in its implementation may be prepared, copied, published and
-  ;; distributed, in whole or in part, without restriction of any kind,
-  ;; provided that the above copyright notice and this paragraph are included
-  ;; on all such copies and derivative works. However, this document itself may
-  ;; not be modified in any way, such as by removing the copyright notice or
-  ;; references to the Scheme Request For Implementation process or editors,
-  ;; except as needed for the purpose of developing SRFIs in which case the
-  ;; procedures for copyrights defined in the SRFI process must be followed, or
-  ;; as required to translate it into languages other than English.
-  ;; 
-  ;; The limited permissions granted above are perpetual and will not be
-  ;; revoked by the authors or their successors or assigns.
-  ;;
-  ;; This document and the information contained herein is provided on an "AS
-  ;; IS" basis and THE AUTHOR AND THE SRFI EDITORS DISCLAIM ALL WARRANTIES,
-  ;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE
-  ;; OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
-  ;; WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. 
-
-  ;; Use your own standard let.
-  ;; Or call a lambda.
-  ;; (define-syntax standard-let
-  ;;
-  ;;   (syntax-rules ()
-  ;;
-  ;;     ((let ((var val) ...) body ...)
-  ;;      ((lambda (var ...) body ...) val ...))))
-
-  (define-syntax let
-    (syntax-rules ()
-      ;; No bindings: use standard-let.
-      [(let () body ...) (standard-let () body ...)]
-      ;; Or call a lambda.
-      ;; ((lambda () body ...))
-
-      ;; All standard bindings: use standard-let.
-      [(let ((var val) ...) body ...) (standard-let ((var val) ...) body ...)]
-      ;; Or call a lambda.
-      ;; ((lambda (var ...) body ...) val ...)
-
-      ;; One standard binding: loop.
-      ;; The all-standard-bindings clause didn't match,
-      ;; so there must be a rest binding.
-      [(let ((var val) . bindings) body ...)
-       (let-loop #f bindings (var) (val) (body ...))]
-
-      ;; Signature-style name: loop.
-      [(let (name binding ...) body ...)
-       (let-loop name (binding ...) () () (body ...))]
-
-      ;; defun-style name: loop.
-      [(let name bindings body ...)
-       (let-loop name bindings () () (body ...))]))
-
-  (define-syntax let-loop
-    (syntax-rules ()
-      ;; Standard binding: destructure and loop.
-      [(let-loop name ((var0 val0) binding ...) (var ...     ) (val ...     ) body)
-       (let-loop name (            binding ...) (var ... var0) (val ... val0) body)]
-
-      ;; Rest binding, no name: use standard-let, listing the rest values.
-      ;; Because of let's first clause, there is no "no bindings, no name" clause.
-      [(let-loop #f (rest-var rest-val ...) (var ...) (val ...) body)
-       (standard-let ((var val) ... (rest-var (list rest-val ...))) . body)]
-      ;; Or call a lambda with a rest parameter on all values.
-      ;; ((lambda (var ... . rest-var) . body) val ... rest-val ...))
-      ;; Or use one of several other reasonable alternatives.
-
-      ;; No bindings, name: call a letrec'ed lambda.
-      [(let-loop name () (var ...) (val ...) body)
-       ((letrec ((name (lambda (var ...) . body)))
-          name)
-        val ...)]
-
-      ;; Rest binding, name: call a letrec'ed lambda.
-      [(let-loop name (rest-var rest-val ...) (var ...) (val ...) body)
-       ((letrec ((name (lambda (var ... . rest-var) . body)))
-          name)
-        val ... rest-val ...)])))
+(define-syntax let
+  (lambda (x)
+    (define (let-args x)
+      (syntax-case x ()
+        ;; Push lhs and rhs to the end of lhs* and rhs*, respectively
+        [(_ ((lhs rhs) . x*) (lhs* ...) (rhs* ...))
+         (identifier? #'lhs)
+         (let-args #'(_ x* (lhs* ... lhs) (rhs* ... rhs)))]
+        ;; Finally handle the rest arguments, if any
+        [(_ (rest arg* ...) (lhs* ...) (rhs* ...))
+         (identifier? #'rest)
+         #'((lhs* ... . rest) (rhs* ... arg* ...))]
+        [(_ () lhs* rhs*) #'(lhs* rhs*)]))
+    (syntax-case x ()
+      ;; Named let
+      [(_ name bindings body ...)
+       (identifier? #'name)
+       (with-syntax ([(lhs* rhs*) (let-args #'(let-args bindings () ()))])
+         #'((letrec ((name (lambda lhs* body ...))) name)
+            . rhs*))]
+      ;; Define-style named let
+      [(_ (name . bindings) body ...)
+       (identifier? #'name)
+       #'(let name bindings body ...)]
+      ;; Let, possibly with rest arguments
+      [(_ bindings body ...)
+       (with-syntax ([(lhs* rhs*) (let-args #'(let-args bindings () ()))])
+         #'((lambda lhs* body ...) . rhs*))]))))

--- a/tests/let.sps
+++ b/tests/let.sps
@@ -1,0 +1,71 @@
+;; Copyright © 2020 Göran Weinholt
+;; SPDX-License-Identifier: MIT
+#!r6rs
+
+;; Tests for SRFI 5
+
+(import
+  (except (rnrs) let)
+  (rnrs eval)
+  (srfi :5 let)
+  (srfi :64 testing))
+
+(test-begin "let")
+(test-equal (let () '())
+            '())
+(test-equal (let ((a 0) (b 1) (c 2))
+              (list a b c))
+            '(0 1 2))
+(test-equal (let ((a 0) (b 1) . (c* 2 3))
+              (list a b c*))
+            '(0 1 (2 3)))
+(test-end "let")
+
+(test-begin "named-let")
+(test-equal (let lp () '())
+            '())
+(test-equal (let lp ((a 0) (b 1) (c 2))
+              (if (= a 10)
+                  (list a b c)
+                  (lp (+ a 1) (+ b 1) (+ c 1))))
+            '(10 11 12))
+(test-equal (let lp ((a 0) (b 1) . (c* 2 3))
+              (if (= a 10)
+                  (list a b c*)
+                  (lp (+ a 1) (+ b 1) (+ (car c*) 1) (+ (cadr c*) 1))))
+            '(10 11 (12 13)))
+(test-equal (let lp ((a 0) . (x))
+              (if (= a 3)
+                  (list a x)
+                  (apply lp (+ a 1) (cons a x))))
+            '(3 (2 1 0)))
+
+(test-end "named-let")
+
+(test-begin "named-let-styled")
+(test-equal (let (lp) '())
+            '())
+(test-equal (let (lp (a 0) (b 1) (c 2))
+              (if (= a 10)
+                  (list a b c)
+                  (lp (+ a 1) (+ b 1) (+ c 1))))
+            '(10 11 12))
+(test-equal (let (lp (a 0) (b 1) . (c* 2 3))
+              (if (= a 10)
+                  (list a b c*)
+                  (lp (+ a 1) (+ b 1) (+ (car c*) 1) (+ (cadr c*) 1))))
+            '(10 11 (12 13)))
+(test-end "named-let-styled")
+
+;; Check if the loop variable is visible to the arguments
+
+(test-begin "let-pitfall")
+(define env (environment '(srfi :5 let)))
+(test-equal (eval '(let lp (x 0) x)
+                  env)
+            '(0))                       ;check that eval works
+(test-error #t (eval '(let lp (x lp) x)
+                     env))
+(test-error #t (eval '(let lp ((x 0) . (y lp)) y)
+                     env))
+(test-end "let-pitfall")


### PR DESCRIPTION
I'm slowly preparing to package chez-srfi for Debian. It's already packaged in Guix and I hope you will not have any objections to including it in Debian as well.

The current SRFI-5 implementation uses the old SRFI license, which is not free according to the Debian Free Software Guidelines. I have reimplemented it from scratch in this PR and have also added a test suite.