### PR TITLE
Added Licensing information.

### DIFF
--- a/%3a143.sls
+++ b/%3a143.sls
@@ -1,3 +1,25 @@
+;; SRFI-143 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+
 (library (srfi :143)
   (export
     fx-width fx-greatest fx-least

--- a/%3a143/fixnums.sls
+++ b/%3a143/fixnums.sls
@@ -1,3 +1,12 @@
+;; SRFI-143 r6rs library implementation
+;;
+;; Implements the fixnum operators specified in SRFI-143 using a combination of
+;; R6RS sepcified version and Chez Scheme provided operators where R6RS does
+;; not include them.  These are in the helpers library and non-Chez Scheme
+;; versions are included for supporting other R6RS implementations.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :143 fixnums)
   (export
     fx-width fx-greatest fx-least

--- a/%3a143/helpers.chezscheme.sls
+++ b/%3a143/helpers.chezscheme.sls
@@ -1,3 +1,10 @@
+;; SRFI-143 Chez Scheme helper implementation
+;;
+;; Imports the fxabs, fxremainder, and fxquotient procedures from Chez Scheme
+;; for the SRFI-143 functions.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :143 helpers)
   (export fxabs fxremainder fxquotient)
   (import (chezscheme)))

--- a/%3a143/helpers.sls
+++ b/%3a143/helpers.sls
@@ -1,3 +1,10 @@
+;; SRFI-143 r6rs helper implementation
+;;
+;; Implemnts the fxabs, fxremainder, and fxquotient procedures for the SRFI-143
+;; functions, using the provided r6rs generics or simple functions.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :143 helpers)
   (export fxabs fxremainder fxquotient)
   (import (rnrs) (rnrs r5rs))

--- a/%3a145.sls
+++ b/%3a145.sls
@@ -1,3 +1,50 @@
+;; SRFI-145 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+;;
+;; Note: This implmentation provides both a Chez Scheme specific implementation
+;; of assumptions, which uses the above copyright and an R6RS generic
+;; implmentation based on the SRFI-145 example which is covered by the
+;; following license:
+;;
+;; Copyright (C) Marc Nieper-Wißkirchen (2016). All Rights Reserved.
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+;; IN THE SOFTWARE.
+
 (library (srfi :145)
   (export assume)
   (import (srfi :145 assumptions)))

--- a/%3a145/assumptions.chezscheme.sls
+++ b/%3a145/assumptions.chezscheme.sls
@@ -1,3 +1,11 @@
+;; SRFI-145 chez scheme implmentation
+;;
+;; Uses Chez Scheme's meta-cond to suppress generating the assumption code when
+;; compilled at optimize-level 3.  Otherwise it uses the Chez Scheme errorf
+;; procedure to raise a nicely formatted exception when the assumption fails.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :145 assumptions)
   (export assume)
   (import (chezscheme))

--- a/%3a145/assumptions.sls
+++ b/%3a145/assumptions.sls
@@ -1,3 +1,11 @@
+;; SRFI-145 r6rs implemntation
+;;
+;; Copyright (C) Marc Nieper-Wißkirchen (2016). All Rights Reserved.
+;;
+;; Slight modifications by Andy Keep.  This uses the SRFI-0 cond-expand and
+;; SRFI-23 error in place of the R7RS versions from the SRFI sample
+;; implementation.
+
 (library (srfi :145 assumptions)
   (export assume)
   (import (except (rnrs) error) (srfi :0) (srfi :23))

--- a/%3a151.sls
+++ b/%3a151.sls
@@ -1,3 +1,55 @@
+;; SRFI-151 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+;;
+;; This implementation contains code from the SRFI-151 example implementation:
+;;
+;; Copyright (C) John Cowan (2016). All Rights Reserved.
+;; 
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+;; IN THE SOFTWARE.
+;;
+;; Which in turn includes some code from the Olin Shiver's SRFI-33 implementation:
+;;
+;; Olin Shivers is the sole author of this code, and he has placed it in the
+;; public domain.
+;;
+;; Licenses are noted inline.  The majority of the rest of the code is simply
+;; wrappers around R6RS functions, or simple extensions.
+
 (library (srfi :151)
   (export
     bitwise-not

--- a/%3a151/bitwise-operations.sls
+++ b/%3a151/bitwise-operations.sls
@@ -1,3 +1,21 @@
+;; SRFI-151 r6rs library implementation
+;;
+;; The following contains a combination of R6RS implementation along with
+;; implementations pulled from the SRFI-151 implementation.
+;;
+;; The R6RS wrappers and simple functions are:
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; The bitwise-eqv implementation is based on the Olin Shiver's SRFI-33
+;; implementation from the SRFI-151 example library:
+;; Olin Shivers is the sole author of this code, and he has placed it in the
+;; public domain.
+;;
+;; The bitwise-fold, bitwise-for-each, bitwise-unfold, and
+;; make-bitwise-generator functions are pulled from John Cowan's SRFI-151
+;; implementation and are:
+;; Copyright John Cowan 2017
+
 (library (srfi :151 bitwise-operations)
   (export
     bitwise-not
@@ -25,6 +43,33 @@
     make-bitwise-generator)
   (import (rnrs))
 
+  ;;; The bitwise-eqv implmentation is based on the one in the SRFI-151
+  ;;; implementation, which extracted it from the SRFI-33 implementation which
+  ;;; carried the following copyright information:
+  ;;;
+  ;;; Olin Shivers is the sole author of this code, and he has placed it in
+  ;;; the public domain.
+  ;;; 
+  ;;; A good implementation might choose to provide direct compiler/interpreter
+  ;;; support for these derived functions, or might simply define them to be
+  ;;; integrable -- i.e., inline-expanded.
+  ;;; 
+  ;;; This is a general definition, but less than efficient.  It should also
+  ;;; receive primitive compiler/interpreter support so that the expensive
+  ;;; n-ary mechanism is not invoked in the standard cases -- that is,
+  ;;; an application of BITWISE-EQV should be rewritten into an equivalent
+  ;;; tree applying some two-argument primitive to the arguments, in the
+  ;;; same manner that statically-known n-ary applications of associative
+  ;;; operations such as + and * are handled efficiently:
+  ;;;   (bitwise-eqv)         => -1
+  ;;;   (bitwise-eqv i)       => i
+  ;;;   (bitwise-eqv i j)     => (%bitwise-eqv i j)
+  ;;;   (bitwise-eqv i j k)   => (%bitwise-eqv (%bitwise-eqv i j) k)
+  ;;;   (bitwise-eqv i j k l) => (%bitwise-eqv (%bitwise-eqv (%bitwise-eqv i j) k) l)
+  ;;;
+  ;;; Note: this implementation takes the advice of the comment avove and
+  ;;; implemets this using case lambade, though Chez Scheme's source optimizer
+  ;;; is relied upon to produce the constants.
   (define bitwise-eqv
     (case-lambda
       [() (bitwise-not (bitwise-xor))]
@@ -161,6 +206,13 @@
 
   (define bits (lambda args (list->bits args)))
 
+  ;; ---- from SRFI-151 other ---
+  ;; The following functions: bitwise-fold, bitwise-for-each, bitwise-unfold,
+  ;; and make-bitwise-generator are taken from John Cowan's implemtation
+  ;; functions from the SRFI-151.
+  ;;
+  ;; Copyright John Cowan 2017
+  ;;
   (define bitwise-fold
     (lambda (proc seed i)
       (let ([n (integer-length i)])
@@ -190,4 +242,6 @@
         (lambda ()
           (let ([r (bitwise-bit-set? i idx)])
             (set! idx (fx+ idx 1))
-            r))))))
+            r)))))
+  ;; ---- END from SRFI-151 other ---
+)

--- a/%3a17.sls
+++ b/%3a17.sls
@@ -1,3 +1,25 @@
+;; SRFI-17 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+
 (library (srfi :17)
   (export getter-with-setter set!
           car cdr

--- a/%3a17/generalized-set%21.chezscheme.sls
+++ b/%3a17/generalized-set%21.chezscheme.sls
@@ -1,3 +1,11 @@
+;; SRFI-17 implementation for Chez Scheme
+;;
+;; Generalized getter and setter for built-in Chez Scheme types.
+;; Uses Chez Scheme's define-proprety and syntactic environment to
+;; provide generalized reference and set! syntax.  Relies on helpers
+;; 
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :17 generalized-set!)
   (export getter-with-setter set!
           car cdr

--- a/%3a17/helpers.chezscheme.sls
+++ b/%3a17/helpers.chezscheme.sls
@@ -1,3 +1,10 @@
+;; SRFI-17 Chez Scheme helpers
+;;
+;; This file contains wrappers for some of the built-in setters used
+;; by the generalized set! syntax.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :17 helpers)
   (export $list-set!
           $hashtable-set! $eq-hashtable-set! $symbol-hashtable-set!

--- a/%3a17/helpers.sls
+++ b/%3a17/helpers.sls
@@ -1,3 +1,11 @@
+;; SRFI-17 generic helpers
+;;
+;; This file contains R6RS compatible wrappers for some of the
+;; built-in setters used by the generalized set! syntax.
+;;
+;; Note: this was never completely fleshed out.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
 
   (define-syntax define-$set-c...r!
     (lambda (x)

--- a/%3a4.sls
+++ b/%3a4.sls
@@ -1,3 +1,25 @@
+;; SRFI-4 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+
 (library (srfi :4)
   (export
     s8vector? make-s8vector s8vector s8vector-length s8vector-ref s8vector-set!

--- a/%3a4/numeric-vectors.sls
+++ b/%3a4/numeric-vectors.sls
@@ -1,3 +1,12 @@
+;; SRFI-4 implementation
+;;
+;; Wraps a bytevector with a scheme record so that the wrapping vector
+;; predicates can uniquely recognize it.  This approach is based on the one
+;; suggested in the SRFI-4 write-up, with macros as helpers to generate the
+;; implementation.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :4 numeric-vectors)
   (export
     s8vector? make-s8vector s8vector s8vector-length s8vector-ref s8vector-set!
@@ -11,7 +20,7 @@
 
     s64vector? make-s64vector s64vector s64vector-length s64vector-ref
     s64vector-set! s64vector->list list->s64vector
-    
+
     u8vector? make-u8vector u8vector u8vector-length u8vector-ref u8vector-set!
     u8vector->list list->u8vector
 
@@ -28,7 +37,7 @@
     f32vector-set! f32vector->list list->f32vector
 
     f64vector? make-f64vector f64vector f64vector-length f64vector-ref
-    f64vector-set! f64vector->list list->f64vector)  
+    f64vector-set! f64vector->list list->f64vector)
   (import (rnrs) (srfi :28))
 
   (define-syntax define-integer-vector
@@ -64,7 +73,7 @@
                            [(bytevector-ref bytevector-set!)
                             (let ([signed-char (if signed? #\s #\u)])
                               (if (fx=? bit-size 8)
-                                  (list 
+                                  (list
                                     (format-id #'k "bytevector-~a~s-ref" signed-char bit-size)
                                     (format-id #'k "bytevector-~a~s-set!" signed-char bit-size))
                                   (list

--- a/%3a60.sls
+++ b/%3a60.sls
@@ -1,3 +1,25 @@
+;; SRFI-60 r6rs library entry
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;; DEALINGS IN THE SOFTWARE.
+
 (library (srfi :60)
   (export logand bitwise-and logior bitwise-ior logxor bitwise-xor lognot
           bitwise-not bitwise-if bitwise-merge logtest any-bits-set?  logcount

--- a/%3a60/integer-bits.sls
+++ b/%3a60/integer-bits.sls
@@ -1,3 +1,12 @@
+;; SRFI-60 R6RS implementation
+;;
+;; Builds out the SRFI-60 specified bitwise operators using the set of bitwise
+;; operators that is part of the standard R6RS library.  In some cases these
+;; could directly use Chez Scheme library procedures directly, but this library
+;; does not do that yet.
+;;
+;; Copyright (c) 2018 - 2020 Andrew W. Keep
+
 (library (srfi :60 integer-bits)
   (export logand bitwise-and logior bitwise-ior logxor bitwise-xor lognot
           bitwise-not bitwise-if bitwise-merge logtest any-bits-set? logcount


### PR DESCRIPTION
Added licensing information to SRFI-4, SRFI-17, SRFI-60, SRFI-143,
SRFI-145, and SRFI-151 at the request of Göran Weinholt.

This will enable the library to be included in a Debian distro.