### PR TITLE
Fix warnings

### DIFF
--- a/%3a125/125.body.scm
+++ b/%3a125/125.body.scm
@@ -89,7 +89,7 @@
     (if %enforce-comparator-type-tests
         (lambda (x . rest)
           (cond ((not (okay? x))
-                 (error "key rejected by hash-table comparator"
+                 (error #f "key rejected by hash-table comparator"
                         x
                         comparator))
                 ((null? rest)
@@ -262,7 +262,7 @@
     (let loop ((kvs rest))
       (cond
        ((null? kvs) #f)
-       ((null? (cdr kvs)) (error "hash-table: wrong number of arguments"))
+       ((null? (cdr kvs)) (error #f "hash-table: wrong number of arguments"))
        ((hashtable-contains? ht (car kvs))
         (error "hash-table: two equivalent keys were provided"
                (car kvs)))

--- a/%3a128/128.body1.scm
+++ b/%3a128/128.body1.scm
@@ -74,8 +74,8 @@
   (make-raw-comparator
     (if (eq? type-test #t) (lambda (x) #t) type-test)
     (if (eq? equality #t) (lambda (x y) (eqv? (ordering x y) 0)) equality)
-    (if ordering ordering (lambda (x y) (error "ordering not supported")))
-    (if hash hash (lambda (x y) (error "hashing not supported")))
+    (if ordering ordering (lambda (x y) (error #f "ordering not supported")))
+    (if hash hash (lambda (x y) (error #f "hashing not supported")))
     (if ordering #t #f)
     (if hash #t #f)))
 
@@ -89,7 +89,7 @@
 (define (comparator-check-type comparator obj)
   (if (comparator-test-type comparator obj)
     #t
-    (error "comparator type check failed" comparator obj)))
+    (error #f "comparator type check failed" comparator obj)))
 
 ;; Invoke the hash function
 (define (comparator-hash comparator obj)

--- a/%3a158/srfi-158-impl.scm
+++ b/%3a158/srfi-158-impl.scm
@@ -246,7 +246,7 @@
 ;; gmerge
 (define gmerge
   (case-lambda
-    ((<) (error "wrong number of arguments for gmerge"))
+    ((<) (error #f "wrong number of arguments for gmerge"))
     ((< gen) gen)
     ((< genleft genright)
      (let ((left (genleft))
@@ -274,7 +274,7 @@
 ;; gmap
 (define gmap
   (case-lambda
-    ((proc) (error "wrong number of arguments for gmap"))
+    ((proc) (error #f "wrong number of arguments for gmap"))
     ((proc gen)
      (lambda ()
        (let ((item (gen)))

--- a/%3a26/cut-impl.scm
+++ b/%3a26/cut-impl.scm
@@ -86,11 +86,11 @@
 ; exported syntax
 
 (define-syntax <>
-  (lambda (x)
-    (syntax-violation #f "misplaced aux keyword <>")))
+  (identifier-syntax
+    (error #f "misplaced aux keyword <>")))
 (define-syntax <...>
-  (lambda (x)
-    (syntax-violation #f "misplaced aux keyword <...>")))
+  (identifier-syntax
+    (error #f "misplaced aux keyword <...>")))
 
 (define-syntax cut
   (syntax-rules ()


### PR DESCRIPTION
This change fixes warnings found by Chez scheme when using the inline compiled SRFI libs.