### PR TITLE
Don't export pk in SRFI 64

### DIFF
--- a/%3a64/testing.sls
+++ b/%3a64/testing.sls
@@ -4,7 +4,6 @@
 
 (library (srfi :64 testing)
   (export
-    pk
     test-begin
     test-end test-assert test-eqv test-eq test-equal
     test-approximate test-error test-apply test-with-runner
@@ -55,11 +54,7 @@
     (srfi :23 error tricks)
     (srfi private include))
 
-  (define (pk . args)
-    (write args)(newline)
-    (car (reverse args)))
-
-  (define (eval form)
+    (define (eval form)
     (rnrs:eval form (environment '(rnrs)
                                  '(rnrs eval)
                                  '(rnrs mutable-pairs)

--- a/%3a64/testing.sls
+++ b/%3a64/testing.sls
@@ -54,7 +54,7 @@
     (srfi :23 error tricks)
     (srfi private include))
 
-    (define (eval form)
+  (define (eval form)
     (rnrs:eval form (environment '(rnrs)
                                  '(rnrs eval)
                                  '(rnrs mutable-pairs)


### PR DESCRIPTION
I don't think this makes sense in SRFI 64 in hindsight.