### PR TITLE
Move include.chezscheme.sls into the install script

### DIFF
--- a/install.chezscheme.sps
+++ b/install.chezscheme.sps
@@ -257,9 +257,12 @@ exec /usr/bin/env ${SCHEME:-scheme} --compile-imported-libraries --script \"$0\"
     (copy-directory (join-path src-dir "private") dest-dir)
     ;; create a null (srfi private include) library since those imports haven't been removed.
     (delete-file (join-path dest-dir "private" "include.sls"))
-    (copy-file
-      (join-path src-dir "private" "install" "include.chezscheme.sls")
-      (join-path dest-dir "private" "include.chezscheme.sls"))))
+    (call-with-output-file (join-path dest-dir "private" "include.chezscheme.sls")
+      (lambda (p)
+        (pretty-print '(library (srfi private include)
+                         (export)
+                         (import (chezscheme)))
+                      p)))))
 
 (define install-tests
   (lambda (src-dir dest-dir)

--- a/private/install/include.chezscheme.sls
+++ b/private/install/include.chezscheme.sls
@@ -1,4 +1,0 @@
-(library (srfi private include)
-  (export)
-  (import (chezscheme))
-  )


### PR DESCRIPTION
The file include.chezscheme.sls is picked up by Akku.scm as a
Chez-specific version of the (srfi private include) library, which in
turn breaks every library that uses it. Let's generate it from
install.chezscheme.sps instead.