### PR TITLE
Fix hour padding for date->string

### DIFF
--- a/%3a19/srfi-19.scm
+++ b/%3a19/srfi-19.scm
@@ -1054,7 +1054,7 @@
 			port)))
    (cons #\k (lambda (date pad-with port)
 	       (display (tm:padding (date-hour date)
-				    #\0 2)
+				    #\space 2)
                         port)))
    (cons #\l (lambda (date pad-with port)
 	       (let ((hr (if (> (date-hour date) 12)


### PR DESCRIPTION
[SRFI-19](https://srfi.schemers.org/srfi-19/srfi-19.html) defines `~k` as blank padded variant of `~H`