### PR TITLE
Updated README.upstream to reflect available SRFIs

### DIFF
--- a/README.upstream
+++ b/README.upstream
@@ -54,6 +54,7 @@ These SRFIs are available:
   (srfi :111 boxes)
   (srfi :113 sets-and-bags)
   (srfi :115 regex)
+  (srfi :116 ilists)
   (srfi :117 list-queues)
   (srfi :125 hashtables)
   (srfi :126 r6rs-hashtables)

--- a/README.upstream
+++ b/README.upstream
@@ -69,6 +69,7 @@ These SRFIs are available:
   (srfi :141 integer-division)
   (srfi :143 fixnums)
   (srfi :145 assumptions)
+  (srfi :146 mappings)
   (srfi :151 bitwise-operations)
   (srfi :152 strings)
   (srfi :156 predicate-combiners)

--- a/README.upstream
+++ b/README.upstream
@@ -65,6 +65,7 @@ These SRFIs are available:
   (srfi :131 records)
   (srfi :132 sorting)
   (srfi :133 vectors)
+  (srfi :134 ideques)
   (srfi :141 integer-division)
   (srfi :143 fixnums)
   (srfi :145 assumptions)

--- a/README.upstream
+++ b/README.upstream
@@ -51,6 +51,7 @@ These SRFIs are available:
   (srfi :78 lightweight-testing)
   (srfi :98 os-environment-variables)
   (srfi :99 records)
+  (srfi :111 boxes)
   (srfi :115 regex)
   (srfi :117 list-queues)
   (srfi :125 hashtables)

--- a/README.upstream
+++ b/README.upstream
@@ -52,6 +52,7 @@ These SRFIs are available:
   (srfi :98 os-environment-variables)
   (srfi :99 records)
   (srfi :111 boxes)
+  (srfi :113 sets-and-bags)
   (srfi :115 regex)
   (srfi :117 list-queues)
   (srfi :125 hashtables)


### PR DESCRIPTION
The list of available SRFIs in the `README.upstream` file was not current. This pull request brings this up to date.