### PR TITLE
Added SRFI 213 implementation for ChezScheme

### DIFF
--- a/%3a213.sls
+++ b/%3a213.sls
@@ -1,0 +1,5 @@
+#!r6rs
+
+(library (srfi :213)
+  (export define-property capture-lookup)
+  (import (srfi :213 impl)))

--- a/%3a213/impl.chezscheme.sls
+++ b/%3a213/impl.chezscheme.sls
@@ -1,0 +1,12 @@
+#!r6rs
+
+(library (srfi :213 impl)
+  (export define-property capture-lookup)
+  (import (rnrs (6))
+          (only (chezscheme) define-property format top-level-bound?))
+
+  ;; The ChezScheme implementation is already doing what is necessary
+  ;; when macro transformer returns a procedure, so we just re-use the
+  ;; implementation-provided lookup.
+  (define (capture-lookup proc)
+    proc))


### PR DESCRIPTION
- Implementation is just re-export of existing ChezScheme facilities.

Note - I'm not sure what's the contribution process so I just tested that the following program works (outputs `123`):

```scheme
#!/usr/bin/env scheme-script

(import (rnrs (6)) (srfi :213))

(define id)
(define key)
(define-syntax get-prop
  (lambda (x)
    (capture-lookup (lambda (lookup)
                      (syntax-case x ()
                        [(_ id key)
                         #`'#,(lookup #'id #'key)])))))

(define-property id key 123)

(display (get-prop id key))
(newline)
```

As far as I understand there is no way to portably implement this SRFI, so I only include Chez implementation for now.