### PR TITLE
Added [SRFI-214] implementation.

### DIFF
--- a/%3a214.sls
+++ b/%3a214.sls
@@ -1,0 +1,47 @@
+#!r6rs
+
+;; This is an R6RS adaptation of the R7RS implementation by the SRFI-214 author,
+;; taken from [here](https://github.com/scheme-requests-for-implementation/srfi-214/tree/master/implementation)
+(library (srfi :214)
+  (export
+          ;; Constructors
+          make-flexvector flexvector
+          flexvector-unfold flexvector-unfold-right
+          flexvector-copy flexvector-reverse-copy
+          flexvector-append flexvector-concatenate flexvector-append-subvectors
+
+          ;; Predicates
+          flexvector? flexvector-empty? flexvector=?
+
+          ;; Selectors
+          flexvector-ref flexvector-front flexvector-back flexvector-length
+
+          ;; Mutators
+          flexvector-add! flexvector-add-front! flexvector-add-back!
+          flexvector-remove! flexvector-remove-front! flexvector-remove-back!
+          flexvector-add-all! flexvector-remove-range! flexvector-clear!
+          flexvector-set! flexvector-swap!
+          flexvector-fill! flexvector-reverse!
+          flexvector-copy! flexvector-reverse-copy!
+          flexvector-append!
+
+          ;; Iteration
+          flexvector-fold flexvector-fold-right
+          flexvector-map flexvector-map! flexvector-map/index flexvector-map/index!
+          flexvector-append-map flexvector-append-map/index
+          flexvector-filter flexvector-filter! flexvector-filter/index flexvector-filter/index!
+          flexvector-for-each flexvector-for-each/index
+          flexvector-count flexvector-cumulate
+
+          ;; Searching
+          flexvector-index flexvector-index-right
+          flexvector-skip flexvector-skip-right
+          flexvector-binary-search
+          flexvector-any flexvector-every flexvector-partition
+
+          ;; Conversion
+          flexvector->vector flexvector->list flexvector->string
+          vector->flexvector list->flexvector string->flexvector
+          reverse-flexvector->list reverse-list->flexvector
+          generator->flexvector flexvector->generator)
+  (import (srfi :214 impl)))

--- a/%3a214/impl.sls
+++ b/%3a214/impl.sls
@@ -1,0 +1,673 @@
+#!r6rs
+
+(library (srfi :214 impl)
+  (export
+   ;; Constructors
+   make-flexvector flexvector
+   flexvector-unfold flexvector-unfold-right
+   flexvector-copy flexvector-reverse-copy
+   flexvector-append flexvector-concatenate flexvector-append-subvectors
+
+   ;; Predicates
+   flexvector? flexvector-empty? flexvector=?
+
+   ;; Selectors
+   flexvector-ref flexvector-front flexvector-back flexvector-length
+
+   ;; Mutators
+   flexvector-add! flexvector-add-front! flexvector-add-back!
+   flexvector-remove! flexvector-remove-front! flexvector-remove-back!
+   flexvector-add-all! flexvector-remove-range! flexvector-clear!
+   flexvector-set! flexvector-swap!
+   flexvector-fill! flexvector-reverse!
+   flexvector-copy! flexvector-reverse-copy!
+   flexvector-append!
+
+   ;; Iteration
+   flexvector-fold flexvector-fold-right
+   flexvector-map flexvector-map! flexvector-map/index flexvector-map/index!
+   flexvector-append-map flexvector-append-map/index
+   flexvector-filter flexvector-filter! flexvector-filter/index flexvector-filter/index!
+   flexvector-for-each flexvector-for-each/index
+   flexvector-count flexvector-cumulate
+
+   ;; Searching
+   flexvector-index flexvector-index-right
+   flexvector-skip flexvector-skip-right
+   flexvector-binary-search
+   flexvector-any flexvector-every flexvector-partition
+
+   ;; Conversion
+   flexvector->vector flexvector->list flexvector->string
+   vector->flexvector list->flexvector string->flexvector
+   reverse-flexvector->list reverse-list->flexvector
+   generator->flexvector flexvector->generator)
+  (import (except (rnrs) vector-fill!)
+          (srfi :26)
+          (srfi :214 parameters)
+          (except (srfi :133 vectors) vector->list list->vector)
+          (srfi :158))
+
+  ;;; Utilities
+
+  ;; Checks if number is non-negative
+  (define (nonnegative? num)
+    (and (number? num) (>= num 0)))
+
+  ;; Returns negated predicate.
+  (define (negate pred?)
+    (lambda args
+      (not (apply pred? args))))
+
+  ;; Asserts that index is valid for the given flexvector.
+  (define (assert-index-validity fv . ids)
+    (let ([len (flexvector-len fv)])
+      (for-each (lambda (i)
+                  (assert (and (>= i 0) (< i len))))
+                ids)))
+
+  ;; Collects groups of `num` length in lst into a new list.
+  (define (group lst num)
+    (define (split l n)
+      (let loop ([acc (list)]
+                 [ls l]
+                 [count 0])
+        (cond [(>= count n) (values (reverse acc) ls)]
+              [(null? ls) (error group "Not enough elements for a group" lst num)]
+              [else (loop (cons (car ls) acc)
+                          (cdr ls)
+                          (+ count 1))])))
+    (assert (positive? num))
+    (let loop ([acc (list)]
+               [source lst])
+      (cond [(null? source) (reverse acc)]
+            [else (let-values ([(grp rest) (split source num)])
+                    (loop (cons grp acc) rest))])))
+
+  ;; Flexvector is represented as backing storage and number of used slots within.
+  (define-record-type (%flexvector %make-flexvector flexvector?)
+    (nongenerative flexvector-vtlmh5fxbj)
+    (fields (mutable vec flexvector-vec flexvector-vec-set!)
+            (mutable len flexvector-len flexvector-len-set!)))
+
+  ;; Convenience wrapper to deconstruct flexvectors into parts.
+  (define-syntax with-flexvectors
+    (syntax-rules ()
+      [(_ ([(vec len) fv] rest ...) body ...)
+       (let* ([fv* fv]
+              [vec (flexvector-vec fv*)]
+              [len (flexvector-len fv*)])
+         (with-flexvectors (rest ...) body ...))]
+      [(_ () body ...)
+       (let ()
+         body ...)]))
+
+  ;; Calls body with start and end clamped to dimensions of the flexvector.
+  (define-syntax with-clamped-range
+    (syntax-rules ()
+      [(_ (fv start end) body ...)
+       (let ([start (max 0 start)]
+             [end (min end (flexvector-len fv))])
+         (assert (<= start end))
+         (let ()
+           body ...))]))
+
+  ;; Convenience definition facility for procedures that accept [start, [end]] optional arguments.
+  (define-syntax define-with-range
+    (syntax-rules (of)
+      [(_ (name fv ... start (end of what)) body ...)
+       (define name
+         (case-lambda
+           [(fv ...)
+            (name fv ... 0)]
+           [(fv ... start)
+            (name fv ... start (flexvector-len what))]
+           [(fv ... start end)
+            (with-clamped-range (what start end)
+              body ...)]))]))
+
+  ;; Returns shortest length of given vectors.
+  (define (shortest-length vecs)
+    (apply min (map flexvector-len vecs)))
+
+  ;; Shortcut macro for over-vectors iterations.
+  (define-syntax with-shortest-length
+    (syntax-rules ()
+      [(_ [(vecs shortest-len) vecs-expr] body ...)
+       (let* ([vecs vecs-expr]
+              [shortest-len (shortest-length vecs)])
+         body ...)]))
+
+  ;; Returns flexvector capacity.
+  (define (flexvector-cap fv)
+    (vector-length (flexvector-vec fv)))
+
+  ;; Makes sure that the flexvector has enough capacity
+  (define (ensure-capacity! fv required-cap)
+    (let ([current-cap (flexvector-cap fv)])
+      (unless (>= current-cap required-cap)
+        (let* ([vec (flexvector-vec fv)]
+               [new-cap ((flexvector-capacity-estimator) current-cap required-cap)];  (exact (expt 2 (+ (floor (log required-cap 2)) 1)))]
+               [new-vec (make-vector new-cap)])
+          (vector-copy! new-vec 0 vec 0 (vector-length vec))
+          (flexvector-vec-set! fv new-vec)))))
+
+  ;; Makes sure capacity requested for flexvector creation is no less than
+  ;; allowed minimal one.
+  (define (ensure-valid-capacity requested-size)
+    (assert (and (exact? requested-size) (>= requested-size 0)))
+    (max requested-size (flexvector-min-capacity)))
+
+  ;; Constructs flexvector with given size and fill.
+  (define make-flexvector
+    (case-lambda
+      [(size)
+       (assert (nonnegative? size))
+       (%make-flexvector (make-vector (ensure-valid-capacity size)) size)]
+      [(size fill)
+       (assert (nonnegative? size))
+       (%make-flexvector (make-vector (ensure-valid-capacity size) fill) size)]))
+
+  ;; Constructs flexvector from given elements.
+  (define (flexvector . els)
+    (cond [(null? els) (make-flexvector 0)]
+          [else (list->flexvector els)]))
+
+  ;; Generates flexvector by applying func to seeds generated by gen until pred returns true.
+  (define (flexvector-unfold pred func gen . seeds)
+    (let ([fv (flexvector)])
+      (do [(seeds seeds (let-values [(seeds (apply gen seeds))]
+                          seeds))]
+          [(apply pred seeds) fv]
+        (flexvector-add-back! fv (apply func seeds)))))
+
+  ;; Generates flexvector like flexvector-unfold does but fill the resulting vector starting
+  ;; from the right end.
+  (define (flexvector-unfold-right pred func gen . seeds)
+    (let ([fv (apply flexvector-unfold pred func gen seeds)])
+      (flexvector-reverse! fv)
+      fv))
+
+  ;; Makes a copy of the flexvector.
+  (define-with-range (flexvector-copy fv start (end of fv))
+    (with-flexvectors ([(vec len) fv])
+      (let ([result (make-flexvector (- end start))])
+        (vector-copy! (flexvector-vec result) 0 vec start end)
+        result)))
+
+  ;; Makes a reverse copy of the flexvector.
+  (define (flexvector-reverse-copy . args)
+    (let ([copy (apply flexvector-copy args)])
+      (flexvector-reverse! copy)
+      copy))
+
+  ;; Appends flexvectors together.
+  (define (flexvector-append fv . rest)
+    (flexvector-concatenate (cons fv rest)))
+
+  ;; Concatenates given list of flexvectors together.
+  (define (flexvector-concatenate fvs)
+    (let* ([total-len (fold-left + 0 (map flexvector-len fvs))]
+           [result (make-flexvector total-len)])
+      (let loop ([vecs fvs]
+                 [offset 0])
+        (cond [(null? vecs) result]
+              [else
+               (let ([current (car vecs)])
+                 (flexvector-copy! result offset current)
+                 (loop (cdr vecs) (+ offset (flexvector-len current))))]))))
+
+  ;; Appends sequence of subvectors specified by vector + offset + count.
+  (define (flexvector-append-subvectors . args)
+    (let* ([triplets (group args 3)]
+           [subvecs (map (lambda (triplet)
+                           (apply flexvector-copy triplet))
+                         triplets)])
+      (flexvector-concatenate subvecs)))
+
+  ;; Is the flexvector empty?
+  (define (flexvector-empty? fv)
+    (zero? (flexvector-len fv)))
+
+  ;; Compares flexvectors. They should have same lengths and their
+  ;; elements should be equal according to elt=?.
+  (define (flexvector=? elt=? . fvs)
+    (define (combine result . es)
+      (and result (apply elt=? es)))
+    (let ([lens (map flexvector-len fvs)])
+      (or (null? fvs) (null? (cdr fvs))
+          (and (apply = lens)
+               (apply flexvector-fold combine #t fvs)))))
+
+  ;; References element at given index in the flexvector.
+  (define (flexvector-ref fv index)
+    (with-flexvectors ([(vec len) fv])
+      (assert-index-validity fv index)
+      (vector-ref vec index)))
+
+  ;; References the first element of an (assumed) non empty flexvector.
+  (define (flexvector-front fv)
+    (flexvector-ref fv 0))
+
+  ;; References the last element of an (assumed) non empty flexvector.
+  (define (flexvector-back fv)
+    (let ([len (flexvector-len fv)])
+      (flexvector-ref fv (- len 1))))
+
+  ;; Returns the length of the flexvector.
+  (define flexvector-length flexvector-len)
+
+  ;; Adds elements els at position i shifting existing elements to the right.
+  (define (flexvector-add! fv i . els)
+    (flexvector-add-all! fv i els))
+
+  ;; Adds elements els at the beginning of the flexvector.
+  (define (flexvector-add-front! fv . els)
+    (flexvector-add-all! fv 0 els))
+
+  ;; Adds elements els at the end of the flexvector.
+  (define (flexvector-add-back! fv . els)
+    (flexvector-add-all! fv (flexvector-len fv) els))
+
+  ;; Adds elements to the flexvector starting at index i.
+  (define (flexvector-add-all! fv i els)
+    (let* ([count (length els)]
+           [len (flexvector-len fv)]
+           [total-len (+ len count)])
+      (ensure-capacity! fv total-len)
+      (let ([vec (flexvector-vec fv)])
+        (vector-copy! vec (+ i count) vec i len)
+        (let loop ([ls els]
+                   [offset 0])
+          (cond [(null? ls)
+                 (flexvector-len-set! fv total-len)
+                 fv]
+                [else (let ([el (car ls)])
+                        (vector-set! vec (+ i offset) el)
+                        (loop (cdr ls) (+ offset 1)))])))))
+
+  ;; Appends flexvector to the first one.
+  (define (flexvector-append! fv . fvs)
+    (let* ([len (flexvector-len fv)]
+           [total-len (fold-left + len (map flexvector-len fvs))])
+      (ensure-capacity! fv total-len)
+      (let ([vec (flexvector-vec fv)])
+        (let loop ([fvs fvs]
+                   [offset len])
+          (cond [(null? fvs)
+                 (flexvector-len-set! fv total-len)
+                 fv]
+                [else (with-flexvectors ([(current-vec current-len) (car fvs)])
+                        (vector-copy! vec offset current-vec 0 current-len)
+                        (loop (cdr fvs) (+ offset current-len)))])))))
+
+  ;; Removes element at position i shifting remaining elements accordingly.
+  (define (flexvector-remove! fv i)
+    (let ([value (flexvector-ref fv i)])
+      (flexvector-remove-range! fv i (+ i 1))
+      value))
+
+  ;; Removes the first element from the flexvector.
+  (define (flexvector-remove-front! fv)
+    (flexvector-remove! fv 0))
+
+  ;; Removes element from the back of flexvector.
+  (define (flexvector-remove-back! fv)
+    (flexvector-remove! fv (- (flexvector-len fv) 1)))
+
+  ;; Removes a range of elements from the vector.
+  (define flexvector-remove-range!
+    (case-lambda
+      [(fv start)
+       (flexvector-remove-range! fv start (flexvector-len fv))]
+      [(fv start end)
+       (with-flexvectors ([(vec len) fv])
+         (let* ([start (max start 0)]
+                [end (min len end)]
+                [move-count (- len end)]
+                [len-delta (- end start)])
+           (assert (<= start end))
+           (unless (zero? move-count)
+             (vector-copy! vec start vec end (+ end move-count)))
+           (flexvector-len-set! fv (- len len-delta))
+           fv))]))
+
+  ;; Clears the flexvector.
+  (define (flexvector-clear! fv)
+    (flexvector-len-set! fv 0)
+    fv)
+
+  ;; Sets the value at index i to el.
+  (define (flexvector-set! fv i el)
+    (assert-index-validity fv i)
+    (with-flexvectors ([(vec len) fv])
+      (let* ([val (vector-ref vec i)])
+        (vector-set! vec i el)
+        val)))
+
+  ;; Swaps elements of flexvector.
+  (define (flexvector-swap! fv i j)
+    (assert-index-validity fv i j)
+    (with-flexvectors ([(vec len) fv])
+      (vector-swap! vec i j)))
+
+  ;; Fills elements between start and end of the flexvector with given fill value.
+  (define-with-range (flexvector-fill! fv fill start (end of fv))
+    (with-flexvectors ([(vec len) fv])
+      (let ([start (max 0 start)]
+            [end (min end len)])
+        (vector-fill! vec fill start end)
+        fv)))
+
+  ;; Reverses the flexvector in place.
+  (define-with-range (flexvector-reverse! fv start (end of fv))
+    (let* ([len (- end start)]
+           [vec (flexvector-vec fv)]
+           [half (floor (/ len 2))])
+      (do [(index 0 (+ index 1))]
+          [(>= index half) fv]
+        (let ([jndex (- len index 1)])
+          (vector-swap! vec (+ start index) (+ start jndex))))))
+
+  ;; Copies section of flexvector `from` defined by `[start, end]` to flexvector `to` starting at index `at`.
+  (define-with-range (flexvector-copy! to at from start (end of from))
+    (let* ([len (flexvector-len to)]
+           [delta (- end start)]
+           [new-len (+ len delta)])
+      (assert (and (>= at 0) (<= at len)))
+      (ensure-capacity! to new-len)
+      (with-flexvectors ([(to-vec to-len) to]
+                         [(from-vec from-len) from])
+        (vector-copy! to-vec at from-vec start end)
+        (flexvector-len-set! to (max len (+ at delta)))
+        to)))
+
+  ;; Copies section of flexvector `from` defined by `[start, end]` in reverse order to flexvector `to` starting at index `at`.
+  (define-with-range (flexvector-reverse-copy! to at from start (end of from))
+    (flexvector-copy! to at from start end)
+    (flexvector-reverse! to at (+ at (- end start))))
+
+  ;; Implementation of fold to reuse in left and right folds.
+  (define (flexvector-fold-impl index-proc reductor initial fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0]
+                 [state initial])
+        (cond [(>= index shortest-len) state]
+              [else (loop (+ index 1)
+                          (apply reductor state (map (cut flexvector-ref <> (index-proc index shortest-len)) vecs)))]))))
+
+  ;; Folds flexvectors over initial value with reductor
+  (define (flexvector-fold reductor initial fv . rest)
+    (define (left-to-right index len)
+      index)
+    (apply flexvector-fold-impl left-to-right reductor initial fv rest))
+
+  ;; Folds flexvectors over initial value with reductor from right to left.
+  (define (flexvector-fold-right reductor initial fv . rest)
+    (define (right-to-left index len)
+      (- len index 1))
+    (apply flexvector-fold-impl right-to-left reductor initial fv rest))
+
+  ;; Helper map building procedure.
+  (define (flexvector-map/index-into! dst proc fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0])
+        (cond [(>= index shortest-len) dst]
+              [else (let ([value (apply proc index (map (cut flexvector-ref <> index) vecs))])
+                      (flexvector-set! dst index value)
+                      (loop (+ index 1)))]))))
+
+  ;; Maps results of application of proc to index and elements of fv + rest back to fv.
+  (define (flexvector-map/index! proc fv . rest)
+    (apply flexvector-map/index-into! fv proc fv rest))
+
+  ;; Maps results of application of proc to elements of fv + rest back to fv.
+  (define (flexvector-map! proc fv . rest)
+    (define (ignore-index . args)
+      (apply proc (cdr args)))
+    (apply flexvector-map/index! ignore-index fv rest))
+
+  ;; Constructs a new flexvector from applications of proc to indices and elements of fv and rest.
+  (define (flexvector-map/index proc fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let ([result (make-flexvector shortest-len)])
+        (apply flexvector-map/index-into! result proc fv rest))))
+
+  ;; Maps results of application of proc to elements of fv + rest into fresh flexvector.
+  (define (flexvector-map proc fv . rest)
+    (define (ignore-index . args)
+      (apply proc (cdr args)))
+    (apply flexvector-map/index ignore-index fv rest))
+
+  ;; Appends results (which should be flexvectors) of application of proc to flexvectors (using index).
+  (define (flexvector-append-map/index proc fv . rest)
+    (flexvector-fold flexvector-append!
+                     (flexvector)
+                     (apply flexvector-map/index proc fv rest)))
+
+  ;; Appends results (which should be flexvectors) of application of proc to flexvectors.
+  (define (flexvector-append-map proc fv . rest)
+    (flexvector-fold flexvector-append!
+                     (flexvector)
+                     (apply flexvector-map proc fv rest)))
+
+  ;; Destructively updates fv to retain only those elements for which pred? returns true.
+  ;; pred? is given an index as first argument.
+  (define (flexvector-filter/index! pred? fv)
+    (with-flexvectors ([(vec len) fv])
+      (let loop ([check-index 0]
+                 [fill-index 0])
+        (cond [(>= check-index len)
+               (flexvector-len-set! fv fill-index)
+               fv]
+              [(pred? check-index (flexvector-ref fv check-index))
+               (flexvector-set! fv fill-index (flexvector-ref fv check-index))
+               (loop (+ check-index 1) (+ fill-index 1))]
+              [else (loop (+ check-index 1) fill-index)]))))
+
+  ;; Destructively updates fv to retain only those elements for which pred? returns true.
+  (define (flexvector-filter! pred? fv)
+    (define (ignore-index index value)
+      (pred? value))
+    (flexvector-filter/index! ignore-index fv))
+
+  ;; Create a new vector that has only those elements for which pred? returns true.
+  ;; pred? is given an index as first argument.
+  (define (flexvector-filter/index pred? fv)
+    (flexvector-filter/index! pred? (flexvector-copy fv)))
+
+  ;; Create a new vector that has only those elements for which pred? returns true.
+  (define (flexvector-filter pred? fv)
+    (flexvector-filter! pred? (flexvector-copy fv)))
+
+  ;; Applies procedure proc to each element of vectors (stopping at shortest one).
+  ;; proc is given an index as first argument.
+  (define (flexvector-for-each/index proc fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (do [(index 0 (+ index 1))]
+          [(>= index shortest-len)]
+        (apply proc index (map (cut flexvector-ref <> index) vecs)))))
+
+  ;; Applies procedure proc to each element of vectors (stopping at shortest one).
+  (define (flexvector-for-each proc fv . rest)
+    (define (ignore-index . args)
+      (apply proc (cdr args)))
+    (apply flexvector-for-each/index ignore-index fv rest))
+
+  ;; Counts elements for which pred? returns true.
+  (define (flexvector-count pred? fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0]
+                 [count 0])
+        (cond [(>= index shortest-len) count]
+              [(apply pred? (map (cut flexvector-ref <> index) vecs))
+               (loop (+ index 1) (+ count 1))]
+              [else (loop (+ index 1) count)]))))
+
+  ;; Constructs new vector using following rule - result[i] = (reductor result[i-1] fv[i])
+  ;; where result[-1] = initial;
+  (define (flexvector-cumulate reductor initial fv)
+    (with-flexvectors ([(vec len) fv])
+      (let* ([result (make-flexvector len)]
+             [new-vec (flexvector-vec result)])
+        (let loop ([index 0]
+                   [state initial])
+          (cond [(>= index len) result]
+                [else (let ([new-state (reductor state (vector-ref vec index))])
+                        (vector-set! new-vec index new-state)
+                        (loop (+ index 1) new-state))])))))
+
+  ;; Finds first index that matches predicate.
+  (define (flexvector-index pred? fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0])
+        (cond [(>= index shortest-len) #f]
+              [(apply pred? (map (cut flexvector-ref <> index) vecs)) index]
+              [else (loop (+ index 1))]))))
+
+  ;; Finds last index that matches predicate.
+  (define (flexvector-index-right pred? fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0])
+        (cond [(>= index shortest-len) #f]
+              [(apply pred? (map (cut flexvector-ref <> (- shortest-len index 1)) vecs)) (- shortest-len index 1)]
+              [else (loop (+ index 1))]))))
+
+  ;; Skips elements matching predicate returning first index of non-matching element.
+  (define (flexvector-skip pred? fv . rest)
+    (apply flexvector-index (negate pred?) fv rest))
+
+  ;; Skips elements matching predicate returning first index of non-matching element moving from right to left.
+  (define (flexvector-skip-right pred? fv . rest)
+    (apply flexvector-index-right (negate pred?) fv rest))
+
+  ;; Performs binary search of a value using given direction computation function.
+  (define-with-range (flexvector-binary-search fv value comp start (end of fv))
+    (let ([vec (flexvector-vec fv)])
+      (vector-binary-search vec value comp start end)))
+
+  ;; Searches first element for which pred? returns generalized true value and returns that value. If no such value found returns #f.
+  (define (flexvector-any pred? fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0])
+        (cond [(>= index shortest-len) #f]
+              [(apply pred? (map (cut flexvector-ref <> index) vecs))]
+              [else (loop (+ index 1))]))))
+
+  ;; Checks if all elements match given predicate and returns last result from it if they do. Otherwise returns #f.
+  (define (flexvector-every pred? fv . rest)
+    (with-shortest-length [(vecs shortest-len) (cons fv rest)]
+      (let loop ([index 0]
+                 [last-value #t])
+        (cond [(>= index shortest-len) last-value]
+              [(apply pred? (map (cut flexvector-ref <> index) vecs)) => (lambda (val)
+                                                                       (loop (+ index 1) val))]
+              [else #f]))))
+
+  ;; Partitions the flexvector into flexvectors of elements that match predicate and those that do not match.
+  (define (flexvector-partition pred? fv)
+    (let ([matching (flexvector)]
+          [non-matching (flexvector)])
+      (flexvector-for-each (lambda (el)
+                             (flexvector-add-back! (if (pred? el) matching non-matching) el))
+                           fv)
+      (values matching non-matching)))
+
+  ;;; Conversion
+
+  ;; Creates a vector from given flexvector.
+  (define-with-range (flexvector->vector fv start (end of fv))
+    (let ([vec (flexvector-vec fv)])
+      (vector-copy vec start end)))
+
+  ;; Creates a flexvector from a given vector.
+  (define vector->flexvector
+    (case-lambda
+      [(vec)
+       (vector->flexvector vec 0)]
+      [(vec start)
+       (vector->flexvector vec start (vector-length vec))]
+      [(vec start end)
+       (let* ([len (- end start)]
+              [result (make-flexvector len)]
+              [fvec (flexvector-vec result)])
+         (vector-copy! fvec 0 vec start end)
+         result)]))
+
+  ;; Common implementation for flexvector->list and reverse-flexvector->list
+  (define (flexvector->list-impl finalizer fv start end)
+    (with-flexvectors ([(vec len) fv])
+      (let loop ([acc (list)]
+                 [index 0])
+        (cond [(>= index len) (finalizer acc)]
+              [else (loop (cons (vector-ref vec index) acc)
+                          (+ index 1))]))))
+
+  ;; Turns flexvector into list.
+  (define-with-range (flexvector->list fv start (end of fv))
+    (flexvector->list-impl reverse fv start end))
+
+  ;; Turns reversed flexvector into list.
+  (define-with-range (reverse-flexvector->list fv start (end of fv))
+    (define (identity l) l)
+    (flexvector->list-impl identity fv start end))
+
+  ;; Conversion helper from list to flexvector.
+  (define (list->flexvector-impl lst index-func)
+    (let* ([len (length lst)]
+           [fv (make-flexvector len)])
+      (let loop ([lst lst]
+                 [index 0])
+        (cond [(null? lst) fv]
+              [else (flexvector-set! fv (index-func len index) (car lst))
+                    (loop (cdr lst) (+ index 1))]))))
+
+  ;; Converts list into flexvector.
+  (define (list->flexvector lst)
+    (list->flexvector-impl lst (lambda (len index) index)))
+
+  ;; Converts reversed list into flexvector.
+  (define (reverse-list->flexvector lst)
+    (list->flexvector-impl lst (lambda (len index) (- len index 1))))
+
+  ;; Converts flexvector of chars to string.
+  (define-with-range (flexvector->string fv start (end of fv))
+    (let-values ([(out fin) (open-string-output-port)])
+      (with-flexvectors ([(vec len) fv])
+        (let loop ([index start])
+          (cond [(>= index end) (fin)]
+                [else (put-char out (vector-ref vec index))
+                      (loop (+ index 1))])))))
+
+  ;; Converts string into a flexvector.
+  (define string->flexvector
+    (case-lambda
+      [(str)
+       (string->flexvector str 0)]
+      [(str start)
+       (string->flexvector str start (string-length str))]
+      [(str start end)
+       (let ([in (open-string-input-port (substring str start end))]
+             [fv (flexvector)])
+         (let loop ([ch (get-char in)])
+           (cond [(eof-object? ch) fv]
+                 [else (flexvector-add-back! fv ch)
+                       (loop (get-char in))])))]))
+
+  ;; Converts flexvector into generator.
+  (define (flexvector->generator fv)
+    (with-flexvectors ([(vec len) fv])
+      (let ([index 0])
+        (lambda ()
+          (cond [(>= index len) (eof-object)]
+                [else
+                 (let ([value (vector-ref vec index)])
+                   (set! index (+ index 1))
+                   value)])))))
+
+  ;; Converts generator into a flexvector.
+  (define (generator->flexvector gen)
+    (let ([fv (flexvector)])
+      (generator-fold (lambda (v r) (flexvector-add-back! r v))
+                      fv
+                      gen))))

--- a/%3a214/parameters.sls
+++ b/%3a214/parameters.sls
@@ -1,0 +1,47 @@
+#!r6rs
+
+;; Extension to SRFI 214 that allows controlling some internal behaviors by
+;; overriding parameters.
+
+(library (srfi :214 parameters)
+  (export flexvector-min-capacity
+          flexvector-capacity-estimator)
+  (import (rnrs)
+          (srfi :39))
+
+  ;; Check for capacity parameter.
+  (define (assert-valid-capacity-value value)
+    (assert (and (number? value) (> value 0)))
+    value)
+
+  ;; Parameter controlling minimal flexvector capacity.
+  (define flexvector-min-capacity
+    (make-parameter 4 assert-valid-capacity-value))
+
+  ;; Check for capacity estimator.
+  ;; Note that check by default calls the value to verify that
+  ;; it takes correct number of arguments and returns a number, so
+  ;; no side effects are expected.
+  (define (assert-valid-capacity-estimator value)
+    (assert (procedure? value))
+    (let* ([example-current 4]
+           [example-requested 8]
+           [example-cap (value example-current example-requested)])
+      (assert (and (number? example-cap)
+                   (exact? example-cap)
+                   (>= example-cap example-requested)))
+      value))
+
+  ;; Returns capacity that is returns multiple of current capacity enough to cover
+  ;; requested one.
+  (define (multiple-of-current-estimator current requested)
+    (assert (and (number? current) (number? requested)
+                 (> current 0) (> requested 0)))
+    (let ([quot (exact (ceiling (/ requested current)))])
+      (* quot current)))
+
+  ;; Parameter whose value is a function, that, given current and required capacity
+  ;; returns the actual capacity to use for the flexvector. Basically, estimate
+  ;; how much to extend the vector to avoid reallocation in the future.
+  (define flexvector-capacity-estimator
+    (make-parameter multiple-of-current-estimator assert-valid-capacity-estimator)))

--- a/tests/flexvectors.sps
+++ b/tests/flexvectors.sps
@@ -1,0 +1,306 @@
+#!r6rs
+
+;; Tests were taken from reference implementation.
+;; That implementation can be found at https://github.com/scheme-requests-for-implementation/srfi-214/tree/master/implementation
+
+(import (srfi :214)
+        (srfi :64)
+        (rnrs))
+
+(test-begin "flexvectors")
+
+(test-equal "flexvector?" #t (flexvector? (flexvector)))
+(test-equal "flexvector-empty?" #t (flexvector-empty? (flexvector)))
+(test-equal "flexvector-empty? non-empty" #f (flexvector-empty? (flexvector 1)))
+(test-equal "flexvector-length" 3 (flexvector-length (make-flexvector 3 #f)))
+(test-equal "flexvector" 3 (flexvector-length (flexvector 1 2 3)))
+
+(let ((fv (flexvector 'a 'b 'c)))
+  (test-equal "flexvector-ref" 'b (flexvector-ref fv 1))
+  (test-equal "flexvector-front" 'a (flexvector-front fv))
+  (test-equal "flexvector-back" 'c (flexvector-back fv))
+  (test-equal "flexvector-set! return" 'b (flexvector-set! fv 1 'd))
+  (test-equal "flexvector-set! mutate" 'd (flexvector-ref fv 1))
+  (test-equal "flexvector-add-back! return" fv (flexvector-add-back! fv 'e))
+  (test-equal "flexvector-add-back! mutate" '(4 . e)
+    (cons (flexvector-length fv)
+          (flexvector-ref fv (- (flexvector-length fv) 1))))
+  (test-equal "flexvector-remove! return" 'd (flexvector-remove! fv 1))
+  (test-equal "flexvector-remove! mutate" '(3 . c)
+    (cons (flexvector-length fv)
+          (flexvector-ref fv 1)))
+  (test-equal "flexvector-clear! return" fv (flexvector-clear! fv))
+  (test-equal "flexvector-clear! mutate" 0 (flexvector-length fv)))
+
+(test-equal "flexvector=? same symbols" #t
+  (flexvector=? eq? (flexvector 'a 'b) (flexvector 'a 'b)))
+(test-equal "flexvector=? different symbols" #f
+  (flexvector=? eq? (flexvector 'a 'b) (flexvector 'b 'a)))
+(test-equal "flexvector=? different lengths" #f
+  (flexvector=? = (flexvector 1 2 3 4 5) (flexvector 1 2 3 4)))
+(test-equal "flexvector=? same numbers" #t
+  (flexvector=? = (flexvector 1 2 3 4) (flexvector 1 2 3 4)))
+(test-equal "flexvector=? 0 arguments" #t
+  (flexvector=? eq?))
+(test-equal "flexvector=? 1 argument" #t
+  (flexvector=? eq? (flexvector 'a)))
+
+(test-equal "make-flexvector" '#(a a a) (flexvector->vector (make-flexvector 3 'a)))
+
+(test-equal "flexvector-unfold"
+  '#(1 4 9 16 25 36 49 64 81 100)
+  (flexvector->vector
+    (flexvector-unfold (lambda (x) (> x 10))
+                       (lambda (x) (* x x))
+                       (lambda (x) (+ x 1))
+                       1)))
+(test-equal "flexvector-unfold-right"
+  '#(100 81 64 49 36 25 16 9 4 1)
+  (flexvector->vector
+    (flexvector-unfold-right (lambda (x) (> x 10))
+                             (lambda (x) (* x x))
+                             (lambda (x) (+ x 1))
+                             1)))
+
+(test-equal "string->flexvector" '#(#\a #\b #\c)
+  (flexvector->vector (string->flexvector "abc")))
+(test-equal "flexvector->string" "abc" (flexvector->string (flexvector #\a #\b #\c)))
+
+(define genlist '(a b c))
+(define (mock-generator)
+  (if (pair? genlist)
+    (let ((value (car genlist)))
+      (set! genlist (cdr genlist))
+      value)
+    (eof-object)))
+
+(test-equal "generator->flexvector" '#(a b c)
+  (flexvector->vector (generator->flexvector mock-generator)))
+(test-equal "flexvector->generator" '(a b c #t)
+  (let* ((gen (flexvector->generator (flexvector 'a 'b 'c)))
+         (one (gen))
+         (two (gen))
+         (three (gen))
+         (four (eof-object? (gen))))
+    (list one two three four)))
+
+; Nondestructive operations on one vector
+(let ((fv (flexvector 10 20 30)))
+  (test-equal "flexvector->vector" '#(10 20 30) (flexvector->vector fv))
+  (test-equal "flexvector->list" '(10 20 30) (flexvector->list fv))
+  (test-equal "reverse-flexvector->list" '(30 20 10) (reverse-flexvector->list fv))
+  (test-equal "flexvector-copy" #t
+    (let ((copy (flexvector-copy fv)))
+      (and (= (flexvector-length fv) (flexvector-length copy))
+           (not (eq? fv copy)))))
+  (test-equal "flexvector-reverse-copy" '#(30 20 10)
+    (flexvector->vector (flexvector-reverse-copy fv)))
+  (test-equal "flexvector-copy start" '#(20 30)
+    (flexvector->vector (flexvector-copy fv 1)))
+  (test-equal "flexvector-copy start end" '#(20)
+    (flexvector->vector (flexvector-copy fv 1 2)))
+  (test-equal "flexvector-for-each" '(30 20 10)
+    (let ((res '()))
+      (flexvector-for-each (lambda (x) (set! res (cons x res))) fv)
+      res))
+  (test-equal "flexvector-for-each/index" '(34 22 10)
+    (let ((res '()))
+      (flexvector-for-each/index
+        (lambda (i x) (set! res (cons (+ x (* i 2)) res)))
+        fv)
+      res))
+  (test-equal "flexvector-map" '#(100 200 300)
+    (flexvector->vector (flexvector-map (lambda (x) (* x 10)) fv)))
+  (test-equal "flexvector-map/index" '#(10 22 34)
+    (flexvector->vector (flexvector-map/index (lambda (i x) (+ x (* i 2))) fv)))
+  (test-equal "flexvector-append-map" '#(10 100 20 200 30 300)
+    (flexvector->vector
+      (flexvector-append-map (lambda (x) (flexvector x (* x 10))) fv)))
+  (test-equal "flexvector-append-map/index" '#(0 10 10 1 20 22 2 30 34)
+    (flexvector->vector
+      (flexvector-append-map/index
+        (lambda (i x) (flexvector i x (+ x (* i 2))))
+        fv)))
+  (test-equal "flexvector-filter" '#(10)
+    (flexvector->vector (flexvector-filter (lambda (x) (< x 15)) fv)))
+  (test-equal "flexvector-filter/index" '#(10 30)
+    (flexvector->vector (flexvector-filter/index (lambda (i x) (not (= i 1))) fv)))
+  (test-equal "flexvector-fold" '(30 20 10)
+    (flexvector-fold (lambda (x y) (cons y x)) '() fv))
+  (test-equal "flexvector-fold-right" '(10 20 30)
+    (flexvector-fold-right (lambda (x y) (cons y x)) '() fv))
+  (test-equal "flexvector-count" 2
+    (flexvector-count (lambda (x) (< x 25)) fv))
+  (test-equal "flexvector-cumulate" '#(3 4 8 9 14 23 25 30 36)
+    (flexvector->vector
+      (flexvector-cumulate + 0 (flexvector 3 1 4 1 5 9 2 5 6))))
+  (test-equal "flexvector-any" '(#t . #f)
+    (cons (flexvector-any (lambda (x) (= x 20)) fv)
+          (flexvector-any (lambda (x) (= x 21)) fv)))
+  (test-equal "flexvector-every" '(#t . #f)
+    (cons (flexvector-every (lambda (x) (< x 40)) fv)
+          (flexvector-every (lambda (x) (< x 30)) fv)))
+  (test-equal "flexvector-index" 1
+    (flexvector-index (lambda (x) (> x 10)) fv))
+  (test-equal "flexvector-index-right" 2
+    (flexvector-index-right (lambda (x) (> x 10)) fv))
+  (test-equal "flexvector-skip" 1
+    (flexvector-skip (lambda (x) (< x 20)) fv))
+  (test-equal "flexvector-skip-right" 0
+    (flexvector-skip-right (lambda (x) (> x 10)) fv))
+  (test-equal "flexvector-partition" '(#(10 20) #(30))
+    (call-with-values
+      (lambda () (flexvector-partition (lambda (x) (< x 25)) fv))
+      (lambda vs (map flexvector->vector vs)))))
+
+(let ((fv (flexvector #\a #\b #\c #\d #\e #\f #\g #\h #\i #\j))
+      (cmp (lambda (char1 char2)
+             (cond ((char<? char1 char2) -1)
+                   ((char=? char1 char2) 0)
+                   (else 1)))))
+  (test-equal "flexvector-binary-search" 3
+    (flexvector-binary-search fv #\d cmp))
+  (test-equal "flexvector-binary-search first" 0
+    (flexvector-binary-search fv #\a cmp))
+  (test-equal "flexvector-binary-search last" 9
+    (flexvector-binary-search fv #\j cmp))
+  (test-equal "flexvector-binary-search not found" #f
+    (flexvector-binary-search fv #\k cmp))
+
+  (test-equal "flexvector-binary-search in range" 5
+    (flexvector-binary-search fv #\f cmp 2 6))
+  (test-equal "flexvector-binary-search out of range" #f
+    (flexvector-binary-search fv #\f cmp 1 5)))
+
+; Nondestructive operations on multiple vectors
+(test-equal "flexvector-append" '#(10 20 30 40 50 60)
+  (flexvector->vector
+    (flexvector-append (flexvector 10 20)
+                       (flexvector)
+                       (flexvector 30 40)
+                       (flexvector 50 60))))
+(test-equal "flexvector-concatenate" '#(10 20 30 40 50 60)
+  (flexvector->vector
+    (flexvector-concatenate
+      (list (flexvector 10 20)
+            (flexvector)
+            (flexvector 30 40)
+            (flexvector 50 60)))))
+(test-equal "flexvector-append-subvectors" '#(a b h i)
+  (flexvector->vector
+    (flexvector-append-subvectors
+      (flexvector 'a 'b 'c 'd 'e) 0 2
+      (flexvector 'f 'g 'h 'i 'j) 2 4)))
+
+; Destructive operations on one vector
+(define-syntax mutate-as
+  (syntax-rules ()
+    ((_ name vec expr)
+      (let ((name (vector->flexvector vec)))
+        expr
+        (flexvector->vector name)))))
+
+(test-equal "flexvector-add! empty" '#(foo)
+  (mutate-as x '#() (flexvector-add! x 0 'foo)))
+(test-equal "flexvector-add! empty multiple" '#(foo bar baz)
+  (mutate-as x '#() (flexvector-add! x 0 'foo 'bar 'baz)))
+(test-equal "flexvector-add! start" '#(foo bar baz)
+  (mutate-as x '#(bar baz) (flexvector-add! x 0 'foo)))
+(test-equal "flexvector-add! start multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(qux quux) (flexvector-add! x 0 'foo 'bar 'baz)))
+(test-equal "flexvector-add! middle" '#(foo bar baz)
+  (mutate-as x '#(foo baz) (flexvector-add! x 1 'bar)))
+(test-equal "flexvector-add! middle multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(foo quux) (flexvector-add! x 1 'bar 'baz 'qux)))
+(test-equal "flexvector-add! end" '#(foo bar baz)
+  (mutate-as x '#(foo bar) (flexvector-add! x 2 'baz)))
+(test-equal "flexvector-add! end multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(foo bar) (flexvector-add! x 2 'baz 'qux 'quux)))
+
+(test-equal "flexvector-add-all!" '#(foo bar baz qux)
+  (mutate-as x '#(foo qux) (flexvector-add-all! x 1 '(bar baz))))
+
+(test-equal "flexvector-add-front! empty" '#(foo)
+  (mutate-as x '#() (flexvector-add-front! x 'foo)))
+(test-equal "flexvector-add-front! empty multiple" '#(foo bar baz)
+  (mutate-as x '#() (flexvector-add-front! x 'foo 'bar 'baz)))
+(test-equal "flexvector-add-front!" '#(foo bar baz)
+  (mutate-as x '#(bar baz) (flexvector-add-front! x 'foo)))
+(test-equal "flexvector-add-front! multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(qux quux) (flexvector-add-front! x 'foo 'bar 'baz)))
+
+(test-equal "flexvector-add-back! empty" '#(foo)
+  (mutate-as x '#() (flexvector-add-back! x 'foo)))
+(test-equal "flexvector-add-back! empty multiple" '#(foo bar baz)
+  (mutate-as x '#() (flexvector-add-back! x 'foo 'bar 'baz)))
+(test-equal "flexvector-add-back!" '#(foo bar baz)
+  (mutate-as x '#(foo bar) (flexvector-add-back! x 'baz)))
+(test-equal "flexvector-add-back! multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(foo bar) (flexvector-add-back! x 'baz 'qux 'quux)))
+
+(test-equal "flexvector-append!" '#(foo bar baz qux)
+  (mutate-as x '#(foo bar) (flexvector-append! x (flexvector 'baz 'qux))))
+(test-equal "flexvector-append! multiple" '#(foo bar baz qux quux)
+  (mutate-as x '#(foo bar) (flexvector-append! x (flexvector 'baz 'qux) (flexvector 'quux))))
+
+(test-equal "flexvector-remove!" '#(foo baz)
+  (mutate-as x '#(foo bar baz) (flexvector-remove! x 1)))
+(test-equal "flexvector-remove! only" '#()
+  (mutate-as x '#(foo) (flexvector-remove! x 0)))
+
+(test-equal "flexvector-remove-front!" '#(bar baz)
+  (mutate-as x '#(foo bar baz) (flexvector-remove-front! x)))
+(test-equal "flexvector-remove-front! only" '#()
+  (mutate-as x '#(foo) (flexvector-remove-front! x)))
+
+(test-equal "flexvector-remove-back!" '#(foo bar)
+  (mutate-as x '#(foo bar baz) (flexvector-remove-back! x)))
+(test-equal "flexvector-remove-back! only" '#()
+  (mutate-as x '#(foo) (flexvector-remove-back! x)))
+
+(test-equal "flexvector-remove-range!" '#(a e f)
+  (mutate-as x '#(a b c d e f) (flexvector-remove-range! x 1 4)))
+(test-equal "flexvector-remove-range! empty range" '#(a b c d e f)
+  (mutate-as x '#(a b c d e f) (flexvector-remove-range! x 1 1)))
+(test-equal "flexvector-remove-range! overflow left" '#(e f)
+  (mutate-as x '#(a b c d e f) (flexvector-remove-range! x -1 4)))
+(test-equal "flexvector-remove-range! overflow right" '#(a b)
+  (mutate-as x '#(a b c d e f) (flexvector-remove-range! x 2 10)))
+
+(test-equal "flexvector-map!" '#(100 200 300)
+  (mutate-as fv '#(10 20 30) (flexvector-map! (lambda (x) (* x 10)) fv)))
+(test-equal "flexvector-map/index!" '#(10 22 34)
+  (mutate-as fv '#(10 20 30) (flexvector-map/index! (lambda (i x) (+ x (* i 2))) fv)))
+(test-equal "flexvector-filter!" '#(10)
+  (mutate-as fv '#(10 20 30) (flexvector-filter! (lambda (x) (< x 15)) fv)))
+(test-equal "flexvector-filter/index!" '#(10 30)
+  (mutate-as fv '#(10 20 30) (flexvector-filter/index! (lambda (i x) (not (= i 1))) fv)))
+
+(test-equal "flexvector-swap!" '#(10 30 20)
+  (mutate-as fv '#(10 20 30) (flexvector-swap! fv 1 2)))
+(test-equal "flexvector-reverse!" '#(30 20 10)
+  (mutate-as fv '#(10 20 30) (flexvector-reverse! fv)))
+
+(test-equal "flexvector-copy!" '#(1 20 30 40 5)
+  (mutate-as fv '#(1 2 3 4 5) (flexvector-copy! fv 1 (flexvector 20 30 40))))
+(test-equal "flexvector-copy! bounded" '#(1 20 30 40 5)
+  (mutate-as fv '#(1 2 3 4 5) (flexvector-copy! fv 1 (flexvector 10 20 30 40 50) 1 4)))
+(test-equal "flexvector-copy! overflow" '#(1 2 30 40 50)
+  (mutate-as fv '#(1 2 3) (flexvector-copy! fv 2 (flexvector 30 40 50))))
+(test-equal "flexvector-reverse-copy!" '#(1 40 30 20 5)
+  (mutate-as fv '#(1 2 3 4 5) (flexvector-reverse-copy! fv 1 (flexvector 20 30 40))))
+(test-equal "flexvector-reverse-copy! bounded" '#(1 40 30 20 5)
+  (mutate-as fv '#(1 2 3 4 5) (flexvector-reverse-copy! fv 1 (flexvector 10 20 30 40 50) 1 4)))
+(test-equal "flexvector-reverse-copy! overflow" '#(1 2 50 40 30)
+  (mutate-as fv '#(1 2 3) (flexvector-reverse-copy! fv 2 (flexvector 30 40 50))))
+
+(test-equal "flexvector-fill!" '#(foo foo foo)
+  (mutate-as x '#(1 2 3) (flexvector-fill! x 'foo)))
+(test-equal "flexvector-fill! start" '#(1 2 bar bar bar)
+  (mutate-as x '#(1 2 3 4 5) (flexvector-fill! x 'bar 2)))
+(test-equal "flexvector-fill! start end" '#(1 2 baz baz 5)
+  (mutate-as x '#(1 2 3 4 5) (flexvector-fill! x 'baz 2 4)))
+(test-equal "flexvector-fill! clamped" '#(qux qux qux)
+  (mutate-as x '#(1 2 3) (flexvector-fill! x 'qux -1 10)))
+
+(test-end "flexvectors")

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -54,6 +54,7 @@ lseqs.sps
 generators-and-accumulators.sps
 fixnums.sps
 sets-and-bags.sps
+flexvectors.sps
 '
 
 fails='


### PR DESCRIPTION
- Implementation is R6RS-portable and depends only on some other SRFIs from this repository.
- Tests were taken from [reference implementation].
- There are some extensions in `(srfi :214 parameters)` that allow customization of flexvector internal behavior.

[SRFI-214]: https://srfi.schemers.org/srfi-214/srfi-214.html
[reference implementation]: https://github.com/scheme-requests-for-implementation/srfi-214