### PR TITLE
Fix SRFI-78 for Ypsilon by not using vanish-define

### DIFF
--- a/%3a78/check.scm
+++ b/%3a78/check.scm
@@ -47,7 +47,7 @@
 
 ; -- utilities --
 
-(define check:write write)
+;(define check:write write)
 
 (define (print/header/padded x header padding)
   (define (print/lines)
@@ -79,7 +79,7 @@
 
 ; -- mode --
 
-(define check:mode #f)
+;(define check:mode #f)
 
 (define (check-set-mode! mode)
   (set! check:mode

--- a/%3a78/lightweight-testing.sls
+++ b/%3a78/lightweight-testing.sls
@@ -16,7 +16,6 @@
     (srfi :39 parameters)
     (srfi :42 eager-comprehensions)
     (srfi :23 error tricks)
-    (for (srfi private vanish) expand)
     (srfi private include))
 
   (define-syntax check:mode
@@ -26,7 +25,6 @@
 
   (define check:mode-param (make-parameter #F))
 
-  (let-syntax ((define (vanish-define define (check:write check:mode))))
-    (SRFI-23-error->R6RS "(library (srfi :78 lightweight-testing))"
-     (include/resolve ("srfi" "%3a78") "check.scm")))
+  (SRFI-23-error->R6RS "(library (srfi :78 lightweight-testing))"
+    (include/resolve ("srfi" "%3a78") "check.scm"))
 )


### PR DESCRIPTION
Ypsilon does not like vanish-define and crashes with "attempt to modify immutable binding" on the definition of check:write. The use of vanish-define seems pretty gratuitous here since check.scm has been modified from the original anyway.