### PR TITLE
fix compose in srfi-171 and add generator-transduce

### DIFF
--- a/%3a171.sls
+++ b/%3a171.sls
@@ -1,6 +1,6 @@
 (library (srfi :171)
   (export rcons reverse-rcons rcount rany revery
-          list-transduce vector-transduce string-transduce bytevector-u8-transduce port-transduce
+          list-transduce vector-transduce string-transduce bytevector-u8-transduce port-transduce generator-transduce
           compose
           tmap tfilter tremove treplace tfilter-map tdrop tdrop-while ttake ttake-while
           tconcatenate tappend-map tdelete-neighbor-dupes tdelete-duplicates tflatten

--- a/%3a171/meta.sls
+++ b/%3a171/meta.sls
@@ -14,7 +14,7 @@
 
 (library (srfi :171 meta)
   (export reduced reduced? unreduce ensure-reduced preserving-reduced
-          list-reduce vector-reduce string-reduce bytevector-u8-reduce port-reduce)
+          list-reduce vector-reduce string-reduce bytevector-u8-reduce port-reduce generator-reduce)
   (import (except (rnrs) define-record-type)
           (srfi :9 records))
 
@@ -87,4 +87,13 @@
           (let ((acc (f acc val)))
             (if (reduced? acc)
                 (unreduce acc)
-                (loop (reader port) acc)))))))
+                (loop (reader port) acc))))))
+
+  (define (generator-reduce f identity gen)
+    (let loop ((val (gen)) (acc identity))
+      (if (eof-object? val)
+          acc
+          (let ((acc (f acc val)))
+            (if (reduced? acc)
+                (unreduce acc)
+                (loop (gen) acc)))))))

--- a/tests/transducers.sps
+++ b/tests/transducers.sps
@@ -1,10 +1,11 @@
 #!r6rs
 
 (import
-  (rnrs)
-  (only (srfi :1) iota)
-  (srfi :64 testing)
-  (srfi :171 transducers))
+ (rnrs)
+ (only (srfi :1) iota)
+ (srfi :64 testing)
+ (srfi :171 transducers)
+ (srfi :158 generators-and-accumulators))
 
 (define (add1 x) (+ x 1))
 
@@ -18,6 +19,7 @@
 (test-equal '(1 2 3 4 5) (list-transduce (tmap add1) rcons numeric-list))
 (test-equal '(0 2 4) (list-transduce (tfilter even?) rcons numeric-list))
 (test-equal '(1 3 5) (list-transduce (compose (tfilter even?) (tmap add1)) rcons numeric-list))
+(test-equal '(2 4 6) (list-transduce (compose (tfilter even?) (tmap add1) (tmap add1)) rcons numeric-list))
 
 (test-equal (string-transduce (tmap char->integer) rcons example-string) (list-transduce (tmap char->integer) rcons list-of-chars))
 (test-equal 6 (string-transduce (tfilter char-alphabetic?) rcount example-string))
@@ -48,6 +50,8 @@
 (test-equal '(0 and 1 and 2 and 3 and 4) (list-transduce (tinterpose 'and) rcons numeric-list))
 
 (test-equal '((-1 . 0) (0 . 1) (1 . 2) (2 . 3) (3 . 4)) (list-transduce (tenumerate (- 1)) rcons numeric-list))
+
+(test-equal '(1 3 5) (generator-transduce (compose (tfilter even?) (tmap add1)) rcons (make-range-generator 0 5)))
 
 (test-end "transducers")
 


### PR DESCRIPTION
My initial commit include an incorrect implementation of compose. When composing more than two functions it was incorrect.

Additionally transducing over generators is very useful.