### PR TITLE
srfi-98 can't work on FreeBSD 14 64bit

### DIFF
--- a/%3a98/os-environment-variables.chezscheme.sls
+++ b/%3a98/os-environment-variables.chezscheme.sls
@@ -123,5 +123,12 @@
            (if (= ptr-to-ptr 0)
                0
                (foreign-ref 'void* ptr-to-ptr 0))))]
+      [(ta6fb a6fb)
+        (load-shared-object "libc.so.7")
+        (lambda ()
+          (let ([ptr-to-ptr (foreign-entry "environ")])
+            (if (= ptr-to-ptr 0)
+              0
+              (foreign-ref 'void* ptr-to-ptr 0))))]
       [else (error 'get-environment-variables
                    "currently unsupoorted on ~s" (machine-type))])))


### PR DESCRIPTION
On FreeBSD 14 64bit:
(machine-type) is ta64fb or a64fb
srfi :98 need to load libc.so.7 to get environ function