### PR TITLE
SRFI 224: Fix build error by removing 'only' import.

### DIFF
--- a/%3a224.sls
+++ b/%3a224.sls
@@ -63,7 +63,7 @@
           (srfi :143)
           (srfi :145)
           (only (srfi :158) make-coroutine-generator)
-          (only (srfi private include) include/resolve))
+          (srfi private include))
 
   (include/resolve ("srfi" "%3a224") "matchers.scm")
   (include/resolve ("srfi" "%3a224") "trie.scm")


### PR DESCRIPTION
This fixes a "missing import for include/resolve" issue that previously occurred while building SRFI 224. It is unclear to me, however, why this patch fixes the problem; replacing `(import (only (srfi private include) include/resolve))` with `(import (srfi private include))` should not fix a missing-import exception.

Thanks to duncan for reporting this problem via `#scheme` on libera.chat.