### PR TITLE
srfi-224: Use R6RS record with fixed nongenerative id.

### DIFF
--- a/%3a224.sls
+++ b/%3a224.sls
@@ -59,6 +59,8 @@
           (rnrs lists (6))
           (only (srfi :1) fold every)
           (srfi :9)
+          (rename (rnrs records syntactic (6))
+                  (define-record-type define-record-type*))
           (only (srfi :128) comparator? =?)
           (srfi :143)
           (srfi :145)

--- a/%3a224/224.scm
+++ b/%3a224/224.scm
@@ -20,10 +20,10 @@
 
 ;;;; Type
 
-(define-record-type <fxmapping>
-  (raw-fxmapping trie)
-  fxmapping?
-  (trie fxmapping-trie))
+(define-record-type* (<fxmapping> raw-fxmapping fxmapping?)
+  (nongenerative fxmapping-7a1f4d5b-a540-462b-82b1-47283c935b85)
+  (fields
+   (immutable trie fxmapping-trie)))
 
 ;;;; Constructors
 


### PR DESCRIPTION
In the "Specification" section of [SRFI-224](https://srfi.schemers.org/srfi-224/srfi-224.html), it says

> In systems supporting R6RS record-type semantics, fxmappings are instances of a nongenerative record type with uid fxmapping-7a1f4d5b-a540-462b-82b1-47283c935b85.

It's the case of Chez Scheme.

* %3a224/224.scm (<fxmapping>): Use R6RS nongenerative record with id fxmapping-7a1f4d5b-a540-462b-82b1-47283c935b85.