### PR TITLE
SRFI 253: Don’t import (scheme), import (rnrs)

### DIFF
--- a/%3a253/data-type-checking.sls
+++ b/%3a253/data-type-checking.sls
@@ -28,7 +28,7 @@
           lambda-checked define-checked
           case-lambda-checked
           define-record-type-checked)
-  (import (scheme))
+  (import (rnrs))
 
   (define-syntax assume
     (syntax-rules ()


### PR DESCRIPTION
This fixes the import that [broke on many non-Chez implementations](https://gitlab.com/weinholt/loko/-/work_items/57#note_3523106358). I actually have no I idea why I put it there 😓