### PR TITLE
Use SRFI 9 instead of R6RS records in SRFI 253

### DIFF
--- a/%3a253/data-type-checking.sls
+++ b/%3a253/data-type-checking.sls
@@ -28,7 +28,8 @@
           lambda-checked define-checked
           case-lambda-checked
           define-record-type-checked)
-  (import (rnrs))
+  (import (except (rnrs) define-record-type)
+          (srfi :9 records))
 
   (define-syntax assume
     (syntax-rules ()


### PR DESCRIPTION
Yet another fix for SRFI 253 discovered when packaging it. Sorry about the influx of PRs 😅