### PR TITLE
SRFI 253: Fix lambda-checked return processing for () and rest args

### DIFF
--- a/%3a253/data-type-checking.sls
+++ b/%3a253/data-type-checking.sls
@@ -101,11 +101,21 @@
         (args ... . last) (checks ...)))))
 
   (define-syntax lambda-checked
-    (syntax-rules ()
+    (syntax-rules (=>)
+      ;; Empty args with return type checking
+      ((_ () => (returns ...) body ...)
+       (lambda ()
+         (values-checked (returns ...) (begin body ...))))
+      ;; No need to parse as there are no args
       ((_ () body ...)
        (lambda () body ...))
+      ;; Regular (positional ... [. rest]) arglist
       ((_ (arg . args) body ...)
        (%lambda-checked lambda-checked (body ...) () () arg . args))
+      ;; arg->list lambda, but with return checking
+      ((_ arg => (returns ...) body ...)
+       (lambda arg
+         (values-checked (returns ...) (begin body ...))))
       ;; Case of arg->list lambda, no-op.
       ((_ arg body ...)
        (lambda arg body ...))))


### PR DESCRIPTION
This fixes a problem of `(lambda-checked () => (returns ...) ...)` and `(lambda-checked rest-arg => (returns ...) ...)` not being expanded properly.